### PR TITLE
Add TLS 1.1 and TLS 1.2 to OpenSSL bindings.

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -82,6 +82,7 @@ exception Method_error
 exception Context_error
 exception Certificate_error
 exception Cipher_error
+exception Diffie_hellman_error
 exception Private_key_error
 exception Unmatching_keys
 exception Invalid_socket
@@ -97,6 +98,7 @@ let () =
   Callback.register_exception "ssl_exn_context_error" Context_error;
   Callback.register_exception "ssl_exn_certificate_error" Certificate_error;
   Callback.register_exception "ssl_exn_cipher_error" Cipher_error;
+  Callback.register_exception "ssl_exn_diffie_hellman_error" Diffie_hellman_error;
   Callback.register_exception "ssl_exn_private_key_error" Private_key_error;
   Callback.register_exception "ssl_exn_unmatching_keys" Unmatching_keys;
   Callback.register_exception "ssl_exn_invalid_socket" Invalid_socket;
@@ -136,6 +138,8 @@ external set_password_callback : context -> (bool -> string) -> unit = "ocaml_ss
 external embed_socket : Unix.file_descr -> context -> socket = "ocaml_ssl_embed_socket"
 
 external set_cipher_list : context -> string -> unit = "ocaml_ssl_ctx_set_cipher_list"
+
+external init_dh_from_file : context -> string -> unit = "ocaml_ssl_ctx_init_dh_from_file"
 
 external load_verify_locations : context -> string -> string -> unit = "ocaml_ssl_ctx_load_verify_locations"
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -275,6 +275,9 @@ type cipher
 (** Set the list of available ciphers for a context. See man ciphers(1) for the format of the string. *)
 val set_cipher_list : context -> string -> unit
 
+(** Init DH parameters from file *)
+val init_dh_from_file : context -> string -> unit
+
 (** Get the cipher used by a socket. *)
 val get_cipher : socket -> cipher
 


### PR DESCRIPTION
This is a silly patch to add preliminary support for TLS 1.1 and TLS 1.2 which unlocks some newer algorithms.

More work is needed in order to have PFS compatible cipher suites (such as DHE and ECDHE).
