### PR TITLE
EC parameters support and fixup on DH parameters race condition.

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -83,6 +83,7 @@ exception Context_error
 exception Certificate_error
 exception Cipher_error
 exception Diffie_hellman_error
+exception Ec_curve_error
 exception Private_key_error
 exception Unmatching_keys
 exception Invalid_socket
@@ -99,6 +100,7 @@ let () =
   Callback.register_exception "ssl_exn_certificate_error" Certificate_error;
   Callback.register_exception "ssl_exn_cipher_error" Cipher_error;
   Callback.register_exception "ssl_exn_diffie_hellman_error" Diffie_hellman_error;
+  Callback.register_exception "ssl_exn_ec_curve_error" Ec_curve_error;
   Callback.register_exception "ssl_exn_private_key_error" Private_key_error;
   Callback.register_exception "ssl_exn_unmatching_keys" Unmatching_keys;
   Callback.register_exception "ssl_exn_invalid_socket" Invalid_socket;
@@ -140,6 +142,8 @@ external embed_socket : Unix.file_descr -> context -> socket = "ocaml_ssl_embed_
 external set_cipher_list : context -> string -> unit = "ocaml_ssl_ctx_set_cipher_list"
 
 external init_dh_from_file : context -> string -> unit = "ocaml_ssl_ctx_init_dh_from_file"
+
+external init_ec_from_named_curve : context -> string -> unit = "ocaml_ssl_ctx_init_ec_from_named_curve"
 
 external load_verify_locations : context -> string -> string -> unit = "ocaml_ssl_ctx_load_verify_locations"
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -278,6 +278,9 @@ val set_cipher_list : context -> string -> unit
 (** Init DH parameters from file *)
 val init_dh_from_file : context -> string -> unit
 
+(** Init EC curve from curve name *)
+val init_ec_from_named_curve : context -> string -> unit
+
 (** Get the cipher used by a socket. *)
 val get_cipher : socket -> cipher
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -636,6 +636,39 @@ CAMLprim value ocaml_ssl_ctx_init_dh_from_file(value context, value dh_file_path
   CAMLreturn(Val_unit);
 }
 
+CAMLprim value ocaml_ssl_ctx_init_ec_from_named_curve(value context, value curve_name)
+{
+  CAMLparam2(context, curve_name);
+  EC_KEY *ecdh = NULL;
+  int nid = 0;
+  SSL_CTX *ctx = Ctx_val(context);
+  char *ec_curve_name = String_val(curve_name);
+
+  if(*ec_curve_name == 0)
+    caml_raise_constant(*caml_named_value("ssl_exn_ec_curve_error"));
+
+  nid = OBJ_sn2nid(ec_curve_name);
+  if(nid == 0){
+    caml_raise_constant(*caml_named_value("ssl_exn_ec_curve_error"));
+  }
+
+  caml_enter_blocking_section();
+  ecdh = EC_KEY_new_by_curve_name(nid);
+  if(ecdh != NULL){
+    if(SSL_CTX_set_tmp_ecdh(ctx,ecdh) != 1){
+      caml_leave_blocking_section();
+      caml_raise_constant(*caml_named_value("ssl_exn_ec_curve_error"));
+    }
+    caml_leave_blocking_section();
+    EC_KEY_free(ecdh);
+  }
+  else{
+    caml_leave_blocking_section();
+    caml_raise_constant(*caml_named_value("ssl_exn_ec_curve_error"));
+  }
+  CAMLreturn(Val_unit);
+}
+
 /*********************************
  * Certificate-related functions *
  *********************************/


### PR DESCRIPTION
Two commits for the following issues:
- Fixup a race condition that could occur on error case with init_dh_from_file (mutex not released).
- Add function to initialize EC parameters from curve name.
