### PR TITLE
Do not leave blocking section twice

### DIFF
--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -953,7 +953,6 @@ CAMLprim value ocaml_ssl_accept(value socket)
   caml_leave_blocking_section();
   if (err != SSL_ERROR_NONE)
     caml_raise_with_arg(*caml_named_value("ssl_exn_accept_error"), Val_int(err));
-  caml_leave_blocking_section();
 
   CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
Test by running ocsigen with ocaml-ssl from master: as soon
as it accepts an ssl connection it'll just hang/misbehave because
Ocaml's internal lock will be in an inconsistent state.

This bug was likely introduced by 13f860b8165566bcf2b5c25ba5118eb330667625,
so it doesn't affect the release ocaml-ssl-4.6, only master.
