### PR TITLE
Add set_client_SNI_hostname to specify client-side SNI hostname.

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -190,6 +190,8 @@ external get_subject : certificate -> string = "ocaml_ssl_get_subject"
 
 external file_descr_of_socket : socket -> Unix.file_descr = "ocaml_ssl_get_file_descr"
 
+external set_client_SNI_hostname : socket -> string -> unit = "ocaml_ssl_set_client_SNI_hostname"
+
 external connect : socket -> unit = "ocaml_ssl_connect"
 
 external verify : socket -> unit = "ocaml_ssl_verify"

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -342,6 +342,10 @@ val open_connection_with_context : context -> Unix.sockaddr -> socket
 (** Close an SSL connection opened with [open_connection]. *)
 val shutdown_connection : socket -> unit
 
+(** Set the hostname the client is attempting to connect to using the Server
+  * Name Indication (SNI) TLS extension. *)
+val set_client_SNI_hostname : socket -> string -> unit
+
 (** Connect an SSL socket. *)
 val connect : socket -> unit
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -48,6 +48,7 @@
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>
+#include <openssl/tls1.h>
 
 #ifdef WIN32
 #include <windows.h>
@@ -854,6 +855,20 @@ CAMLprim value ocaml_ssl_embed_socket(value socket_, value context)
 
   CAMLreturn(block);
 }
+
+CAMLprim value ocaml_ssl_set_client_SNI_hostname(value socket, value vhostname)
+{
+  CAMLparam2(socket, vhostname);
+  SSL *ssl       = SSL_val(socket);
+  char *hostname = String_val(vhostname);
+
+  caml_enter_blocking_section();
+  SSL_set_tlsext_host_name(ssl, hostname);
+  caml_leave_blocking_section();
+
+  CAMLreturn(Val_unit);
+}
+
 
 CAMLprim value ocaml_ssl_connect(value socket)
 {


### PR DESCRIPTION
No attempt is done at checking SSL_set_tlsext_host_name(SSL_ctrl)'s return
value because I could not find it documented anywhere.

I have verified that the `SSL_set_tlsext_host_name` macro exists in both OpenSSL 0.9.8
(since 2007, see https://github.com/openssl/openssl/commit/865a90eb4f0b0e3abbdd9dc2d3a4d57595575315 ) and >1.0 branches, so adding it poses
 no compatibility problems.
