### PR TITLE
Support disabling SSL protocol versions

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -139,6 +139,8 @@ external set_password_callback : context -> (bool -> string) -> unit = "ocaml_ss
 
 external embed_socket : Unix.file_descr -> context -> socket = "ocaml_ssl_embed_socket"
 
+external disable_protocols : context -> protocol list -> unit = "ocaml_ssl_disable_protocols"
+
 external set_cipher_list : context -> string -> unit = "ocaml_ssl_ctx_set_cipher_list"
 
 external init_dh_from_file : context -> string -> unit = "ocaml_ssl_ctx_init_dh_from_file"

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -279,6 +279,9 @@ val set_verify_depth : context -> int -> unit
   * are a core part of the SSL/TLS protocol.*)
 type cipher
 
+(** Disable all protocols from the list *)
+val disable_protocols : context -> protocol list -> unit
+
 (** Set the list of available ciphers for a context. See man ciphers(1) for the format of the string. *)
 val set_cipher_list : context -> string -> unit
 


### PR DESCRIPTION
Given the [vulnerabilities in SSLv3](https://www.openssl.org/~bodo/ssl-poodle.pdf) it'd be good to support disabling it, using SSL_OP_NO_SSLv3 and similar.

Example usage:
```ocaml
Ssl.disable_protocols !Ocsigen_http_client.sslcontext [Ssl.SSLv23];
```