### PR TITLE
Functions to restrict accepted protocols and honor server cipher preferences

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -150,6 +150,8 @@ external embed_socket : Unix.file_descr -> context -> socket = "ocaml_ssl_embed_
 
 external set_cipher_list : context -> string -> unit = "ocaml_ssl_ctx_set_cipher_list"
 
+external honor_cipher_order : context -> unit = "ocaml_ssl_ctx_honor_cipher_order"
+
 external init_dh_from_file : context -> string -> unit = "ocaml_ssl_ctx_init_dh_from_file"
 
 external init_ec_from_named_curve : context -> string -> unit = "ocaml_ssl_ctx_init_ec_from_named_curve"

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -27,6 +27,13 @@ type protocol =
   | TLSv1_1
   | TLSv1_2
 
+type protocol_restriction =
+  | NO_SSLv2
+  | NO_SSLv3
+  | NO_TLSv1
+  | NO_TLSv1_1
+  | NO_TLSv1_2
+
 type context
 
 type certificate
@@ -132,6 +139,8 @@ type context_type =
   | Both_context
 
 external create_context : protocol -> context_type -> context = "ocaml_ssl_create_context"
+
+external set_protocol_restriction : context -> protocol_restriction list -> unit = "ocaml_ssl_ctx_set_proto"
 
 external use_certificate : context -> string -> string -> unit = "ocaml_ssl_ctx_use_certificate"
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -200,13 +200,23 @@ val init : ?thread_safe:bool -> unit -> unit
     occurred. *)
 val get_error_string : unit -> string
 
-(** Protocol used by SSL. *)
+(** Protocol used by SSL as the connection method. Can be further restricted
+* with {!set_protocol_restriction}. *)
 type protocol =
-  | SSLv23 (** SSL v3 protocol but can rollback to v2 *)
-  | SSLv3 (** SSL v3 protocol *)
-  | TLSv1 (** TLS v1 protocol *)
-  | TLSv1_1 (** TLS v1.1 protocol *)
-  | TLSv1_2 (** TLS v1.2 protocol *)
+  | SSLv23 (** understand SSLv2, SSLv3, TLSv1, TLSv1.1 and TLSv1.2 protocols *)
+  | SSLv3 (** SSLv3 protocol only *)
+  | TLSv1 (** TLSv1 protocol only *)
+  | TLSv1_1 (** TLSv1.1 protocol only *)
+  | TLSv1_2 (** TLSv1.2 protocol only *)
+
+(** Protocols not to be used in the SSL/TLS handshake (see
+* {!set_protocol_restriction}). *)
+type protocol_restriction =
+  | NO_SSLv2
+  | NO_SSLv3
+  | NO_TLSv1
+  | NO_TLSv1_1
+  | NO_TLSv1_2
 
 (** An SSL abstract socket. *)
 type socket
@@ -235,6 +245,9 @@ type context_type =
 
 (** Create a context. *)
 val create_context : protocol -> context_type -> context
+
+(** Restrict the protocols to be accepted in the SSL/TLS handshake. *)
+val set_protocol_restriction : context -> protocol_restriction list -> unit
 
 (** [use_certificate ctx cert privkey] makes the context [ctx] use [cert] as
   * certificate's file name (in PEM format) and [privkey] as private key file

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -295,6 +295,13 @@ type cipher
 (** Set the list of available ciphers for a context. See man ciphers(1) for the format of the string. *)
 val set_cipher_list : context -> string -> unit
 
+(** When choosing a cipher, use the server's preferences instead of the client
+  * preferences. When not set, the SSL server will always follow the clients
+  * preferences. When set, the SSLv3/TLSv1 server will choose following its
+  * own preferences. Because of the different protocol, for SSLv2 the server
+  * will send its list of preferences to the client and the client chooses.*)
+val honor_cipher_order : context -> unit
+
 (** Init DH parameters from file *)
 val init_dh_from_file : context -> string -> unit
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -551,6 +551,33 @@ CAMLprim value ocaml_ssl_ctx_set_default_passwd_cb(value context, value cb)
   CAMLreturn(Val_unit);
 }
 
+static int proto_table[5] =
+{
+ SSL_OP_NO_SSLv2,
+ SSL_OP_NO_SSLv3,
+ SSL_OP_NO_TLSv1,
+#ifdef HAVE_TLS11
+ SSL_OP_NO_TLSv1_1,
+#else
+ 0,
+#endif
+#ifdef HAVE_TLS12
+ SSL_OP_NO_TLSv1_2
+#else
+ 0
+#endif
+};
+
+CAMLprim value ocaml_ssl_ctx_set_proto(value context, value prot)
+{
+ CAMLparam2(context, prot);
+ SSL_CTX *ctx = Ctx_val(context);
+ long flags = caml_convert_flag_list(prot, proto_table);
+ SSL_CTX_set_options(ctx, flags);
+
+ CAMLreturn(Val_unit);
+}
+
 /****************************
  * Cipher-related functions *
  ****************************/

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -578,6 +578,15 @@ CAMLprim value ocaml_ssl_ctx_set_proto(value context, value prot)
  CAMLreturn(Val_unit);
 }
 
+CAMLprim value ocaml_ssl_ctx_honor_cipher_order(value context)
+{
+ CAMLparam1(context);
+ SSL_CTX *ctx = Ctx_val(context);
+
+ SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+ CAMLreturn(Val_unit);
+}
+
 /****************************
  * Cipher-related functions *
  ****************************/


### PR DESCRIPTION
The easiest workaround for the POODLE vulnerability is to disable SSLv3 support.
Refer to https://www.openssl.org/~bodo/ssl-poodle.pdf
This PR adds a function allowing to do so.

It also includes a function to honor the cipher preference from the server (i.e., allowing ocaml-ssl clients to do something equivalent to `SSLHonorCipherOrder true` in Apache).