### PR TITLE
Add functions for reading into/writing from bigarrays, avoiding copy.

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -78,6 +78,8 @@ type verify_error =
   | Error_v_keyusage_no_certsign
   | Error_v_application_verification
 
+type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
 exception Method_error
 exception Context_error
 exception Certificate_error
@@ -200,7 +202,18 @@ external verify : socket -> unit = "ocaml_ssl_verify"
 
 external write : socket -> string -> int -> int -> int = "ocaml_ssl_write"
 
+external write_bigarray : socket -> bigarray -> int -> int -> int = "ocaml_ssl_write_bigarray"
+
+external write_bigarray_blocking :
+  socket -> bigarray -> int -> int -> int = "ocaml_ssl_write_bigarray_blocking"
+
 external read : socket -> string -> int -> int -> int = "ocaml_ssl_read"
+
+external read_into_bigarray :
+  socket -> bigarray -> int -> int -> int = "ocaml_ssl_read_into_bigarray"
+
+external read_into_bigarray_blocking :
+  socket -> bigarray -> int -> int -> int = "ocaml_ssl_read_into_bigarray_blocking"
 
 external accept : socket -> unit = "ocaml_ssl_accept"
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -60,6 +60,8 @@ type ssl_error =
   (** The operation did not complete; the same TLS/SSL I/O function should be
       called again later. *)
 
+type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
 (** The SSL method could not be initalized. *)
 exception Method_error
 
@@ -381,6 +383,30 @@ val read : socket -> string -> int -> int -> int
 
 (** [write sock buf off len] sends data over a connected SSL socket. *)
 val write : socket -> string -> int -> int -> int
+
+(** [read_into_bigarray sock ba off len] receives data from a connected SSL socket.
+    This function releases the runtime while the read takes place. *)
+val read_into_bigarray : socket -> bigarray -> int -> int -> int
+
+(** [read_into_bigarray_blocking sock ba off len] receives data from a
+    connected SSL socket.
+    This function DOES NOT release the runtime while the read takes place: it
+    must be used with nonblocking sockets. *)
+val read_into_bigarray_blocking : socket -> bigarray -> int -> int -> int
+
+(** [write sock buf off len] sends data over a connected SSL socket. *)
+val write : socket -> string -> int -> int -> int
+
+(** [write_bigarray sock ba off len] sends data over a connected SSL socket.
+    This function releases the runtime while the read takes place.
+  *)
+val write_bigarray : socket -> bigarray -> int -> int -> int
+
+(** [write_bigarray sock ba off len] sends data over a connected SSL socket.
+    This function DOES NOT release the runtime while the read takes place: it
+    must be used with nonblocking sockets.
+  *)
+val write_bigarray_blocking : socket -> bigarray -> int -> int -> int
 
 
 (** {3 High-level communication functions} *)


### PR DESCRIPTION
Also include "blocking" variants that do not release the runtime, intended to
be used with nonblocking sockets. These functions allow better performance
with e.g. `Lwt_ssl`, by getting rid of two copy operations (`Lwt_bytes` to string buffer,
that buffer to the malloc'ed buffer allocated in `ocaml_ssl_write`)
plus one malloc/free pair per write.
