### PR TITLE
Revert "Be safe_string compatible."

### DIFF
--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -377,10 +377,10 @@ val verify : socket -> unit
 val file_descr_of_socket : socket -> Unix.file_descr
 
 (** [read sock buf off len] receives data from a connected SSL socket. *)
-val read : socket -> Bytes.t -> int -> int -> int
+val read : socket -> string -> int -> int -> int
 
 (** [write sock buf off len] sends data over a connected SSL socket. *)
-val write : socket -> Bytes.t -> int -> int -> int
+val write : socket -> string -> int -> int -> int
 
 
 (** {3 High-level communication functions} *)


### PR DESCRIPTION
Reverts savonet/ocaml-ssl#16

I will merge this, once a solution for backwards compabtility has been found.
