### PR TITLE
Fix build on pre-4.02.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -35,6 +35,7 @@ export CLIBFLAGS = @LDFLAGS@
 export CPPFLAGS = @CPPFLAGS@
 export NO_CUSTOM = yes
 OCAMLFLAGS = @OCAMLFLAGS@
+export PACKS = bytes
 
 define PROJ_ssl
   SOURCES = ssl_stubs.c ssl.mli ssl.ml


### PR DESCRIPTION
This fixes the build, while remaining compatible with 4.02's "safe strings", but `make dist` still fails because the `doc` target doesn't work. Sure enough, hardcoding the rule to use `ocamlfind ocamldoc -package bytes` does the trick, but it completely bypasses `configure`'s detection.