### PR TITLE
Fix META file for OCaml 4.01 and earlier by including the Bytes package

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,9 @@
-0.5.0 (unreleased)
+0.5.1 (unreleased)
+=====
+
+* Fix META file for versions of OCaml older than 4.02.0.
+
+0.5.0 (2015-05-10)
 =====
 * Allow to honor server cipher preferences (thanks mfp, closes #18).
 * Add functions for reading into/writing from bigarrays, avoiding copy (thanks

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([ocaml-ssl],[0.5.0],[savonet-users@lists.sourceforge.net])
+AC_INIT([ocaml-ssl],[0.5.1],[savonet-users@lists.sourceforge.net])
 
 VERSION=$PACKAGE_VERSION
 AC_MSG_RESULT([configuring $PACKAGE_STRING])

--- a/src/META.in
+++ b/src/META.in
@@ -1,7 +1,7 @@
 name="Ssl"
 version="@VERSION@"
 description="OCaml bindings to libssl"
-requires="unix"
+requires="unix bytes"
 archive(byte) = "ssl.cma"
 archive(native) = "ssl.cmxa"
 archive(mt,byte) = "ssl_threads.cma"


### PR DESCRIPTION
This fixes compilation of a number of packages such as Ocsigenserver
on older versions of OCaml