### PR TITLE
Enable safe-string compatiblity

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+author: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+build: [
+  ["autoconf"]
+  ["./configure" "--prefix" prefix] { os != "darwin" }
+  ["sh" "-exc"
+   "./configure --prefix \"%{prefix}%\" CPPFLAGS=\"$CPPFLAGS -I/opt/local/include -I/usr/local/opt/openssl/include\""
+  ] { os = "darwin" }
+  [make]
+]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" name]]
+depends: [
+  "ocamlfind" {build}
+  "conf-which" {build}
+  "conf-openssl"
+  "base-bytes"
+  "conf-autoconf"
+]

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -225,6 +225,8 @@ external verify : socket -> unit = "ocaml_ssl_verify"
 
 external write : socket -> Bytes.t -> int -> int -> int = "ocaml_ssl_write"
 
+external write_substring : socket -> string -> int -> int -> int = "ocaml_ssl_write"
+
 external write_bigarray : socket -> bigarray -> int -> int -> int = "ocaml_ssl_write_bigarray"
 
 external write_bigarray_blocking :
@@ -265,12 +267,11 @@ let open_connection ssl_method sockaddr =
 let shutdown_connection = shutdown
 
 let output_string ssl s =
-  ignore (write ssl s 0 (String.length s))
+  ignore (write_substring ssl s 0 (String.length s))
 
 let output_char ssl c =
-  let tmp = Bytes.create 1 in
-    Bytes.set tmp 0 c;
-    ignore (write ssl tmp 0 1)
+  let tmp = String.make 1 c in
+    ignore (write_substring ssl tmp 0 1)
 
 let output_int ssl i =
   let tmp = Bytes.create 4 in
@@ -288,7 +289,7 @@ let input_string ssl =
     while !r <> 0
     do
       r := read ssl buf 0 bufsize;
-      ret := !ret ^ (Bytes.sub buf 0 !r)
+      ret := !ret ^ (Bytes.sub_string buf 0 !r)
     done;
     !ret
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -408,6 +408,9 @@ val read_into_bigarray_blocking : socket -> bigarray -> int -> int -> int
 (** [write sock buf off len] sends data over a connected SSL socket. *)
 val write : socket -> Bytes.t -> int -> int -> int
 
+(** [write_substring sock str off len] sends data over a connected SSL socket. *)
+val write_substring : socket -> string -> int -> int -> int
+
 (** [write_bigarray sock ba off len] sends data over a connected SSL socket.
     This function releases the runtime while the read takes place.
   *)


### PR DESCRIPTION
Currently, ocaml-ssl doesn't compile on opam switches with safe-string enabled. This PR fixes the issue.
I also added an ```opam``` file to help contributors and opam integration.