### PR TITLE
Fixed issue #42 for macOS w/o Homebrew

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,8 +1,11 @@
 module C = Configurator.V1
 
+let directory_exists fsp =
+  Sys.file_exists fsp && Sys.is_directory fsp
+
 let default c : C.Pkg_config.package_conf =
   if C.ocaml_config_var_exn c "system" = "macosx" then
-    if Sys.is_directory "/usr/local/opt/openssl" then
+    if directory_exists "/usr/local/opt/openssl" then
       { libs = ["-L/usr/local/opt/openssl/lib"]
       ; cflags = ["-I/usr/local/opt/openssl/include"]
       }


### PR DESCRIPTION
The cause of the exception is the application of `Sys.is_directory` to a non-existent path, as is specified in its documentation.