### PR TITLE
Windows support - Delete symlinked opam file

### DIFF
--- a/opam
+++ b/opam
@@ -1,1 +1,0 @@
-ssl.opam


### PR DESCRIPTION
This helps Windows support, I'm currently hitting another issue when testing locally but this would be a good first step.