### PR TITLE
Support reading of cert/private key from memory

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -157,6 +157,8 @@ external create_context : protocol -> context_type -> context = "ocaml_ssl_creat
 
 external use_certificate : context -> string -> string -> unit = "ocaml_ssl_ctx_use_certificate"
 
+external use_certificate_from_string : context -> string -> string -> unit = "ocaml_ssl_ctx_use_certificate_from_string"
+
 external set_password_callback : context -> (bool -> string) -> unit = "ocaml_ssl_ctx_set_default_passwd_cb"
 
 external embed_socket : Unix.file_descr -> context -> socket = "ocaml_ssl_embed_socket"

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -245,6 +245,8 @@ val create_context : protocol -> context_type -> context
   * name. *)
 val use_certificate : context -> string -> string -> unit
 
+val use_certificate_from_string : context -> string -> string -> unit
+
 (** Set the callback function called to get passwords for encrypted PEM files.
   * The callback function takes a boolean argument which indicates if it's used
   * for reading/decryption ([false]) or writing/encryption ([true]).


### PR DESCRIPTION
This PR adds wrapper function to configure certificate/private key using in-memory buffers