### PR TITLE
Add `get_verify_error_string`, `get_start_date`, `get_expiration_date`

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -175,6 +175,8 @@ external set_default_verify_paths : context -> bool = "ocaml_ssl_ctx_set_default
 
 external get_verify_result : socket -> int = "ocaml_ssl_get_verify_result"
 
+external get_verify_error_string : int -> string = "ocaml_ssl_get_verify_error_string"
+
 type verify_mode =
   | Verify_peer
   | Verify_fail_if_no_peer_cert
@@ -219,6 +221,10 @@ external write_certificate : string -> certificate -> unit = "ocaml_ssl_write_ce
 external get_issuer : certificate -> string = "ocaml_ssl_get_issuer"
 
 external get_subject : certificate -> string = "ocaml_ssl_get_subject"
+
+external get_start_date : certificate -> Unix.tm = "ocaml_ssl_get_start_date"
+
+external get_expiration_date : certificate -> Unix.tm = "ocaml_ssl_get_expiration_date"
 
 external file_descr_of_socket : socket -> Unix.file_descr = "ocaml_ssl_get_file_descr"
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -343,6 +343,10 @@ val get_issuer : certificate -> string
 (** Get the subject of a certificate. *)
 val get_subject : certificate -> string
 
+val get_start_date : certificate -> Unix.tm
+
+val get_expiration_date : certificate -> Unix.tm
+
 (** [load_verify_locations ctxt cafile capath] specifies the locations for the
     context [ctx], at which CA certificates for verification purposes are
     located. [cafile] should be the name of a CA certificates file in PEM format
@@ -361,6 +365,9 @@ val set_default_verify_paths : context -> bool
 (** Get the verification result. *)
 val get_verify_result : socket -> int
 
+(** Get a human readable verification error message for the verification error
+    Its input should be the result of calling [get_verify_result]. *)
+val get_verify_error_string : int -> string
 
 (** {2 Creating, connecting and closing sockets} *)
 

--- a/ssl.opam
+++ b/ssl.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2.1"}
   "base-unix"
-  "conf-openssl"
+  "conf-libssl"
 ]
 synopsis: "Bindings for OpenSSL"
 authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"


### PR DESCRIPTION
`get_verify_error_string`: This function returns a human readable
verification error message for a verification result

`get_start_date`, `get_expiration_date`: Return the start / expiration
dates for a certificate, respectively.

Also tweaks the OPAM file to depend on conf-libssl as per
https://github.com/ocaml/opam-repository/pull/14600