### PR TITLE
Adapt to Dune 2.0

### DIFF
--- a/src/config/dune
+++ b/src/config/dune
@@ -1,3 +1,3 @@
 (executable
  (name discover)
- (libraries dune.configurator))
+ (libraries dune-configurator))

--- a/ssl.opam
+++ b/ssl.opam
@@ -12,6 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.2.1"}
+  "dune-configurator"
   "base-unix"
   "conf-libssl"
 ]


### PR DESCRIPTION
Dune 2.0 doesn't include `dune.configurator`, it needs to be installed
separately. This diff adds `dune-configurator` as a dependency to the
opam file.