### PR TITLE
Fix building on OpenBSD, allow one-way shutdown

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -276,7 +276,7 @@ external accept : socket -> unit = "ocaml_ssl_accept"
 
 external flush : socket -> unit = "ocaml_ssl_flush"
 
-external shutdown : socket -> unit = "ocaml_ssl_shutdown"
+external shutdown : socket -> bool = "ocaml_ssl_shutdown"
 
 let open_connection_with_context context sockaddr =
   let domain = Unix.domain_of_sockaddr sockaddr in
@@ -291,6 +291,12 @@ let open_connection_with_context context sockaddr =
 
 let open_connection ssl_method sockaddr =
   open_connection_with_context (create_context ssl_method Client_context) sockaddr
+
+let close_notify = shutdown
+
+let rec shutdown sock =
+  if not (close_notify sock)
+  then shutdown sock
 
 let shutdown_connection = shutdown
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -421,7 +421,13 @@ val accept : socket -> unit
 (** Flush an SSL connection. *)
 val flush : socket -> unit
 
-(** Close an SSL connection. *)
+(** Send close notify to the peer. This is SSL_shutdown(3).
+ *  returns [true] if shutdown is finished, [false] in case [close_notify]
+ *  needs to be called a second time. *)
+val close_notify : socket -> bool
+
+(** Close a SSL connection.
+  * Send close notify to the peer and wait for close notify from peer. *)
 val shutdown : socket -> unit
 
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1660,12 +1660,16 @@ CAMLprim value ocaml_ssl_shutdown(value socket)
 
   caml_enter_blocking_section();
   ret = SSL_shutdown(ssl);
-  if (!ret)
-    SSL_shutdown(ssl);
   caml_leave_blocking_section();
-  /* close(SSL_get_fd(SSL_val(socket))); */
-
-  CAMLreturn(Val_unit);
+  switch (ret) {
+    case 0:
+    case 1:
+      /* close(SSL_get_fd(SSL_val(socket))); */
+      CAMLreturn(Val_int(ret));
+    default:
+      ret = SSL_get_error(ssl, ret);
+      caml_raise_with_arg(*caml_named_value("ssl_exn_connection_error"), Val_int(ret));
+  }
 }
 
 /* ======================================================== */


### PR DESCRIPTION
* To send an `EOF` over ssl you need to be able to initiate a one-way shutdown
* Fix building against LibreSSL on OpenBSD

See also https://github.com/ocsigen/lwt_ssl/pull/2 and https://github.com/mirage/ocaml-conduit/pull/319