### PR TITLE
TLS1_3_VERSION must be ifdef'ed

### DIFF
--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -905,9 +905,11 @@ CAMLprim value ocaml_ssl_version(value socket)
       ret = 4;
       break;
 
+#ifdef TLS1_3_VERSION
     case TLS1_3_VERSION:
       ret = 5;
       break;
+#endif
 
     default:
       caml_failwith("Ssl.version");


### PR DESCRIPTION
Symbol TLS1_3_VERSION is not available in all openssl releases and
therefore must be ifdef'ed to avoid a compilation error.

This is just a quick fix. I believe the correct thing to do is to use `HAVE_TLS13` et al. to guard each of the cases in this match. 

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>