### PR TITLE
Restore support for openssl < 1.1.0

### DIFF
--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -905,9 +905,11 @@ CAMLprim value ocaml_ssl_version(value socket)
       ret = 4;
       break;
 
+#ifdef HAVE_TLS13
     case TLS1_3_VERSION:
       ret = 5;
       break;
+#endif
 
     default:
       caml_failwith("Ssl.version");


### PR DESCRIPTION
e.g. CentOS 7 or Oraclelinux 7 still ship with such old version as 1.0.2