### PR TITLE
Let open_connection_with_context work with IPv6 destination

### DIFF
--- a/examples/alpn.ml
+++ b/examples/alpn.ml
@@ -21,12 +21,7 @@ let test_server proto_list =
   in
   Ssl.init ();
   let sockaddr = Unix.ADDR_INET(Unix.inet_addr_of_string "127.0.0.1", 4433) in
-  let domain =
-    begin match sockaddr with
-    | Unix.ADDR_UNIX _ -> Unix.PF_UNIX
-    | Unix.ADDR_INET (_, _) -> Unix.PF_INET
-    end
-  in
+  let domain = Unix.domain_of_sockaddr sockaddr in
   let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
   let ctx = Ssl.create_context Ssl.TLSv1_2 Ssl.Server_context in
   Ssl.use_certificate ctx certfile privkey;

--- a/examples/stalkd.ml
+++ b/examples/stalkd.ml
@@ -35,12 +35,7 @@ let log s =
 
 let establish_threaded_server server_handler sockaddr nbconn =
   log "establishing server";
-  let domain =
-    begin match sockaddr with
-    | Unix.ADDR_UNIX _ -> Unix.PF_UNIX
-    | Unix.ADDR_INET (_, _) -> Unix.PF_INET
-    end
-  in
+  let domain = Unix.domain_of_sockaddr sockaddr in
   let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
   let handle_connexion (s, caller) =
     let inet_addr_of_sockaddr = function

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -279,11 +279,7 @@ external flush : socket -> unit = "ocaml_ssl_flush"
 external shutdown : socket -> unit = "ocaml_ssl_shutdown"
 
 let open_connection_with_context context sockaddr =
-  let domain =
-    match sockaddr with
-      | Unix.ADDR_UNIX _ -> Unix.PF_UNIX
-      | Unix.ADDR_INET(_, _) -> Unix.PF_INET
-  in
+  let domain = Unix.domain_of_sockaddr sockaddr in
   let sock =
     Unix.socket domain Unix.SOCK_STREAM 0 in
     try


### PR DESCRIPTION
Currently this function creates an IPv4 socket when passed an IPv6 sockaddr, which fails later in Unix.connect().
By respecting the address family of the sockaddr is shorter code and solves the problem.

This was needed to teach a lightly patched savonet/ocaml-cry to use TLS over IPv6.