### PR TITLE
Properly detect ASN1_TIME_to_tm

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -31,6 +31,7 @@ let function_tests =
   ; "TLSv1_2_method", "HAVE_TLS12"
   ; "EC_KEY_free", "HAVE_EC"
   ; "SSL_set_alpn_protos", "HAVE_ALPN"
+  ; "ASN1_TIME_to_tm", "HAVE_ASN1_TIME_TO_TM"
   ]
 
 let macro_tests =

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1175,7 +1175,7 @@ static value alloc_tm(struct tm *tm)
   return res;
 }
 
-#ifdef ASN1_TIME_to_tm
+#ifdef HAVE_ASN1_TIME_TO_TM
 CAMLprim value ocaml_ssl_get_start_date(value certificate)
 {
   CAMLparam1(certificate);


### PR DESCRIPTION
In savonet/ocaml-ssl/pull/75 detection was implemented with an #ifdef
check.  However ASN1_TIME_to_tm() was never available as a macro in
openssl-1.1.1 releases, so a simple #ifdef check will never succeed.

Instead, use dune-configurator to detect ASN1_TIME_to_tm() availability.

Note: ASN1_TIME_to_tm() is not available in LibreSSL yet, mostly because
it wasn't on the radar as a public function used by other projects.
Hopefully it should become available in the next LibreSSL releases.