### PR TITLE
Add license to opam metadata

### DIFF
--- a/ssl.opam
+++ b/ssl.opam
@@ -5,6 +5,7 @@ maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
 homepage: "https://github.com/savonet/ocaml-ssl"
 dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
 bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
I'm unsure whether this SPDX identifier is correct as it also has an exception for OpenSSL, there's a similar exception, but mentions OpenVPN explicitely: https://spdx.org/licenses/exceptions-index.html

I could add a "WITH openssl-exception", but this doesn't have a meaning in the SPDX world and some parsers might complain about an invalid license, any ideas about this?