### PR TITLE
Fix ocaml-ssl segfault with multicore

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -186,11 +186,9 @@ type verify_mode =
   | Verify_fail_if_no_peer_cert
   | Verify_client_once
 
-type verify_callback
+type verify_callback = unit
 
-external get_client_verify_callback_ptr : unit -> verify_callback = "ocaml_ssl_get_client_verify_callback_ptr"
-
-let client_verify_callback = get_client_verify_callback_ptr ()
+let client_verify_callback = ()
 
 external set_client_verify_callback_verbose : bool -> unit = "ocaml_ssl_set_client_verify_callback_verbose"
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -264,7 +264,7 @@ type verify_mode =
   | Verify_client_once (** Implies [Verify_peer]. *)
 
 (** A callback function for verification. Warning: this might change in the future. *)
-type verify_callback
+type verify_callback = unit
 
 (** Client's verification callback. Warning: this might change in the future. *)
 val client_verify_callback : verify_callback

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -559,11 +559,6 @@ CAMLprim value ocaml_ssl_digest(value vevp, value vcert)
   CAMLreturn(vdigest);
 }
 
-CAMLprim value ocaml_ssl_get_client_verify_callback_ptr(value unit)
-{
-  return (value)client_verify_callback;
-}
-
 static int client_verify_callback_verbose = 1;
 
 CAMLprim value ocaml_ssl_set_client_verify_callback_verbose(value verbose)
@@ -610,7 +605,7 @@ CAMLprim value ocaml_ssl_ctx_set_verify(value context, value vmode, value vcallb
   }
 
   if (Is_block(vcallback))
-    callback = (int(*) (int, X509_STORE_CTX*))Field(vcallback, 0);
+    callback = (int(*) (int, X509_STORE_CTX*)) client_verify_callback;
 
   caml_enter_blocking_section();
   SSL_CTX_set_verify(ctx, mode, callback);


### PR DESCRIPTION
fixes https://github.com/savonet/ocaml-ssl/issues/76

- stops returning a C function as an OCaml value.
- This fix should be backwards compatible, as we keep the exact same interface
- it wasn't possible to override the verification callback before (just turning it off or on), so this shouldn't break anyone