### PR TITLE
OCaml 5.0 fix: eliminate out-of-heap pointer for `client_verify_callback`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 - Add `digest` function (#65, #66).
 - Restore compatibility with openssl < 1.1.0 (#73).
 - Improved compatibility with OCaml 5 (#79).
+- Fix `client_verify_callback` for `NO_NAKED_POINTERS` mode. A user-provided
+  verification function in C remains an out-of-heap pointer for 4.x for
+  compatibility, but is boxed for OCaml 5.x or 4.x when configured with
+  `--disable-naked-pointers`. (#83)
 
 0.5.10 (2021-02-01)
 ======


### PR DESCRIPTION
OCaml 5.0 doesn't permit out-of-heap pointers, as noted in #76.

A search in GitHub doesn't reveal an example of it, but contrary to the solution in #81, it is was possible to override the verification callback - the function must necessarily be written in C, and anything doing that would simply have had a similar primitive. The approach here continues to allow that - if there is any C code out there which was doing this, then it would need updating to box the function pointer as well in "no naked pointers" mode.