### PR TITLE
Fix a segfault in `alpn_select_cb` under OCaml 5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Unreleased
 - Improve `use_certificate_from_string` (#71) to read any type of key (rather
   than just RSA).
 
+- Fix a segmentation fault in the ALPN selection callback under OCaml 5 (#89).
+
 0.5.11
 =====
 


### PR DESCRIPTION
This uses @gasche's suggestion from https://github.com/ocaml/ocaml/issues/11485#issuecomment-1211562643

Further follow-up fixes might be needed too.