### PR TITLE
Ensure openssl is installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-version }}
+    - name: Ensure openssl
+      run: brew install openssl@3
     - name: Setup opam
       run: opam pin add -n .
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         ocaml-compiler: ${{ matrix.ocaml-version }}
     - name: Ensure openssl
+      if: runner.os == 'macOS'
       run: brew install openssl@3
     - name: Setup opam
       run: opam pin add -n .


### PR DESCRIPTION
Adds an extra step to install openssl 3.0, this is a workaround that fixes macos build test