### PR TITLE
Fix spelling errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Unreleased
 - Add a few verification functions (#71):
   - `add_extra_chain_cert` to send additional chain certificates to the peer.
   - `add_cert_to_store`: to allow verification of the peer certificate CA.
-  - `set_ip`: sets the expected IP address to be verified on a SSL socket.
+  - `set_ip`: sets the expected IP address to be verified on an SSL socket.
 - Improve `use_certificate_from_string` (#71) to read any type of key (rather
   than just RSA).
 - Fix a segmentation fault in the ALPN selection callback under OCaml 5 (#89).
@@ -140,7 +140,7 @@ Unreleased
 =====
 - file_descr_of_socket is not marked as deprecated anymore.
 - Patched the Makefile to be compatible with FreeBSD (thanks Jaap Boender).
-- Explicitely link with libcrypto since we use it. Compilation should now work
+- Explicitly link with libcrypto since we use it. Compilation should now work
   on Mac OS X too (thanks Janne Hellsten).
 
 0.4.0 (2006-09-09)
@@ -160,7 +160,7 @@ Unreleased
   address to be passed to a restarted non-blocking write operation, which is
   useful since the OCaml garbage collector may move buffers around between
   calls.
-- We do not need to store explicitely the file descriptor for SSL sockets.
+- We do not need to store explicitly the file descriptor for SSL sockets.
 - Corrected checking of errors in ocaml_ssl_read (thanks Vincent Balat and
   Nataliya Guts).
 - input_char now raises End_of_file when no byte could be read (thanks Nataliya
@@ -177,7 +177,7 @@ Unreleased
 - Put connect, accept and flush (and all other functions) in blocking_section to
   allow other threads to run in the meantime.
 - Unified the three context creation functions in create_context, the
-  certificate to use should now be sepcified with use_certificate (sorry for the
+  certificate to use should now be specified with use_certificate (sorry for the
   API-breakage).
 - Added the get_verify_result function.
 - Using Store_field instead of Field(...) = ...
@@ -188,7 +188,7 @@ Unreleased
 - Many thanks to Thomas Fischbacher for his patches:
 - Corrected int / val bugs when raising exceptions from C (those where found by
   Mike Furr too, thanks).
-- Added many fonctions (but in Caml instead of C).
+- Added many functions (but in Caml instead of C).
 - Context creation functions now take the protocol as argument.
 - Added the create_context function (for client and server connections).
 - Added functions for verifying certificates: client_verify_callback,

--- a/examples/alpn.ml
+++ b/examples/alpn.ml
@@ -49,7 +49,7 @@ let test_server proto_list =
   in
   let inet_addr = inet_addr_of_sockaddr caller in
   let ip = Unix.string_of_inet_addr inet_addr in
-  log (Printf.sprintf "openning connection for [%s]" ip);
+  log (Printf.sprintf "opening connection for [%s]" ip);
   let () =
     match Ssl.get_negotiated_alpn_protocol ssl_s with
     | None -> log "no protocol selected"

--- a/examples/stalkd.ml
+++ b/examples/stalkd.ml
@@ -44,7 +44,7 @@ let establish_threaded_server server_handler sockaddr nbconn =
     in
     let inet_addr = inet_addr_of_sockaddr caller in
     let ip = Unix.string_of_inet_addr inet_addr in
-    log (Printf.sprintf "openning connection for [%s]" ip);
+    log (Printf.sprintf "opening connection for [%s]" ip);
     server_handler inet_addr s;
     Ssl.shutdown s
   in
@@ -81,7 +81,7 @@ let () =
          let m = Bytes.sub buf 0 l in
          let msg = Bytes.sub m 0 ((Bytes.length m) - 1) in
          let msg = Bytes.to_string msg in
-         log (Printf.sprintf "revceived '%s'" msg);
+         log (Printf.sprintf "received '%s'" msg);
          if msg = "exit" then
            (
              log "A client has quit";

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -26,7 +26,7 @@
 
 (** {1 Exceptions and errors} *)
 
-(** An ssl error has occured (see SSL_get_error(3ssl) for details). *)
+(** An ssl error has occurred (see SSL_get_error(3ssl) for details). *)
 type ssl_error =
   | Error_none
   (** No error happened. This is never raised and should disappear in future
@@ -60,7 +60,7 @@ type ssl_error =
 
 type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-(** The SSL method could not be initalized. *)
+(** The SSL method could not be initialized. *)
 exception Method_error
 
 exception Context_error
@@ -72,7 +72,7 @@ exception Ec_curve_error
 (** The SSL server certificate could not be initialized. *)
 exception Certificate_error of string
 
-(** The SSL server private key could not be intialized. *)
+(** The SSL server private key could not be initialized. *)
 exception Private_key_error of string
 
 (** The SSL private key does not match the certificate public key. *)
@@ -90,10 +90,10 @@ exception Connection_error of ssl_error
 (** Failed to accept an SSL connection. *)
 exception Accept_error of ssl_error
 
-(** An error occured while reading data. *)
+(** An error occurred while reading data. *)
 exception Read_error of ssl_error
 
-(** An error occured while writing data. *)
+(** An error occurred while writing data. *)
 exception Write_error of ssl_error
 
 (** Why did the certificate verification fail? *)
@@ -184,7 +184,7 @@ type verify_error =
   | Error_v_application_verification
   (** An application specific error. Unused. *)
 
-(** An error occured while verifying the certificate. *)
+(** An error occurred while verifying the certificate. *)
 exception Verify_error of verify_error
 
 
@@ -192,7 +192,7 @@ exception Verify_error of verify_error
 
 (** Initialize SSL functions. Should be called before calling any other
     function. The parameter [thread_safe] should be set to true if you use
-    threads in you application (the same effect can achived by calling
+    threads in you application (the same effect can achieved by calling
     [Ssl_threads.init] first. *)
 val init : ?thread_safe:bool -> unit -> unit
 
@@ -239,13 +239,13 @@ type context_type =
 val create_context : protocol -> context_type -> context
 
 (** Add an additional certificate to the extra chain certificates
-    associated with the [ctx]. Extra chain certificates will be 
-    sent to the peer for verification and are sent in order following the 
-    end entity certificate. The value should be contents of the 
+    associated with the [ctx]. Extra chain certificates will be
+    sent to the peer for verification and are sent in order following the
+    end entity certificate. The value should be contents of the
     certificate as string in PEM format. *)
 val add_extra_chain_cert : context -> string -> unit
 
-(** Add a certificate to the [ctx] trust storage. The value should be contents 
+(** Add a certificate to the [ctx] trust storage. The value should be contents
     of the certificate as string in PEM format. *)
 val add_cert_to_store : context -> string -> unit
 
@@ -467,7 +467,7 @@ val set_host : socket -> string -> unit
     The condensed "::" notation is supported for IPv6 addresses. *)
 val set_ip : socket -> string -> unit
 
-(** Get the file descriptor associated with a socket. It is primarly useful for
+(** Get the file descriptor associated with a socket. It is primarily useful for
     [select]ing on it; you should not write or read on it. *)
 val file_descr_of_socket : socket -> Unix.file_descr
 

--- a/tests/ssl_certs.ml
+++ b/tests/ssl_certs.ml
@@ -1,7 +1,7 @@
 open Alcotest
 open Util
 
-let test_read_cert () = 
+let test_read_cert () =
   let cert = Ssl.read_certificate "client.pem" in
   check bool "no errors" true (Ssl.get_error_string () |> check_ssl_no_error );
   let issuer = Ssl.get_issuer cert in
@@ -26,13 +26,13 @@ let test_cert_connection () =
   let cert = Ssl.get_certificate ssl in
   let subject = Ssl.get_subject cert in
   let verify_result = Ssl.get_verify_result ssl in
-  let error_string = Ssl.get_verify_error_string 0 in 
-  check bool "set default succeded" true set_default;
+  let error_string = Ssl.get_verify_error_string 0 in
+  check bool "set default succeeded" true set_default;
   check string "check certificate" "/C=US/ST=California/L=San Francisco/O=Piaf/CN=CA" subject;
   check int "check verify result" 0 verify_result;
   check string "check error string" "ok" error_string
 
-let () = 
+let () =
   Alcotest.run "Ssl certificate functions"
     [
       ( "Certificates",

--- a/tests/ssl_test.ml
+++ b/tests/ssl_test.ml
@@ -8,7 +8,7 @@ let hex_digest digest =
   in
   go [] (String.length digest - 1) |> String.concat ":"
 
-(* The reference hashes come from Firefox’ certificate viewer. It doesn’t show
+(* The reference hashes come from Firefox's certificate viewer. It doesn't show
  * the SHA384 hash, hence its absence from the tests. *)
 
 let test_sha1 () =


### PR DESCRIPTION
## Summary
- Fix spelling errors.
- Remove some trailing spaces.
- Replace unicode `’` with ASCII `'`.