### PR TITLE
start work on noalloc (raising exception on ocaml side)

### DIFF
--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -55,6 +55,12 @@ type ssl_error =
   | Error_want_accept
       (** The operation did not complete; the same TLS/SSL I/O function should
           be called again later. *)
+  | Error_want_async
+  | Error_want_async_job
+  | Error_want_client_hello_cb
+  | Error_want_retry_verify
+      (** The operation did not complete; the same TLS/SSL I/O function should
+          be called again later. *)
 
 type bigarray =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -29,6 +29,10 @@ type ssl_error =
       (** No error happened. This is never raised and should disappear in future
           versions. *)
   | Error_ssl
+      (** A non-recoverable, fatal error in the SSL library occurred, usually a
+          protocol error. The OpenSSL error queue contains more information on
+          the error. If this error occurs then no further I/O operations should
+          be performed on the connection and SSL_shutdown() must not be called. *)
   | Error_want_read
       (** The operation did not complete; the same TLS/SSL I/O function should
           be called again later. *)
@@ -56,11 +60,23 @@ type ssl_error =
       (** The operation did not complete; the same TLS/SSL I/O function should
           be called again later. *)
   | Error_want_async
+      (** The operation did not complete because an asynchronous engine is still
+          processing data. The TLS/SSL I/O function should be called again
+          later. The function must be called from the same thread that the
+          original call was made from. *)
   | Error_want_async_job
+      (** The asynchronous job could not be started because there were no async
+          jobs available in the pool. The application should retry the operation
+          after a currently executing asynchronous operation for the current
+          thread has completed. *)
   | Error_want_client_hello_cb
+      (** The operation did not complete because an application callback set by
+          SSL_CTX_set_client_hello_cb() has asked to be called again. The
+          TLS/SSL I/O function should be called again later. Details depend on
+          the application. *)
   | Error_want_retry_verify
-      (** The operation did not complete; the same TLS/SSL I/O function should
-          be called again later. *)
+      (** See
+          https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_verify.html *)
 
 type bigarray =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1759,7 +1759,17 @@ CAMLprim value ocaml_ssl_flush_blocking(value socket) {
   bio = SSL_get_wbio(ssl);
   if (bio) {
     ret = BIO_flush(bio);
+    /* From https://www.openssl.org/docs/man1.1.1/man3/BIO_flush.html:
+     *
+     *   RETURN VALUES
+     *
+     *   BIO_flush() returns 1 for success and 0 or -1 for failure.
+     */
     if (ret != 1 && BIO_should_retry(bio))
+      /* We return `-2` as a special return value (BIO_flush can only return
+       * -1 <= ret <= 1) to signal to OCaml, without allocating, that the
+       *  operation should be retried.
+       */
       ret = -2;
   }
 


### PR DESCRIPTION
I started moving some code on the ocaml side, allowing [@@noalloc] annotation and reducing the number of C lines.
Currently I tested only on 
- `Runtime_lock.ssl_read`
- `Runtime_lock.ssl_write`
 
First tests show no real difference in timings, but the argument of simplifying the C side may be relevant and more tests are needed.

I just pushed that PR to have comments.