### PR TITLE
bug fixes in c interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Unreleased
   threads to run concurrently, they don't perform any copying in the underlying
   data, leading certain workloads to be faster than their counterparts that
   release the lock. (#106)
+- Fix calls in C stubs that need to call `ERR_clear_error` before the underlying
+  OpenSSL call (#118)
 
 0.5.13 (2022-10-20)
 =====

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -301,7 +301,7 @@ end
 
 (* Same as above, but doesn't release the lock. *)
 module Runtime_lock_base = struct
-  external connect : socket -> unit = "ocaml_ssl_connect"
+  external connect : socket -> unit = "ocaml_ssl_connect_blocking"
 
   external accept : socket -> unit = "ocaml_ssl_accept_blocking"
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1840,7 +1840,7 @@ CAMLprim value ocaml_ssl_flush(value socket)
     if (ret != 1) {
       caml_acquire_runtime_system();
       caml_raise_with_arg(*caml_named_value("ssl_exn_flush_error"),
-			  Val_bool(ret==-1));
+			  Val_bool(BIO_should_retry(bio)));
     };
   }
   caml_acquire_runtime_system();
@@ -1860,7 +1860,7 @@ CAMLprim value ocaml_ssl_flush_blocking(value socket)
     int ret = BIO_flush(bio);
     if (ret != 1) {
       caml_raise_with_arg(*caml_named_value("ssl_exn_flush_error"),
-			  Val_bool(ret==-1));
+			  Val_bool(BIO_should_retry(bio)));
     };
   }
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1860,7 +1860,7 @@ CAMLprim value ocaml_ssl_flush_blocking(value socket)
     int ret = BIO_flush(bio);
     if (ret != 1) {
       caml_raise_with_arg(*caml_named_value("ssl_exn_flush_error"),
-			  Val_bool(BIO_should_retry(bio)));
+			  Val_bool(ret==-1));
     };
   }
 

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1874,6 +1874,7 @@ CAMLprim value ocaml_ssl_shutdown(value socket)
   int ret;
 
   caml_release_runtime_system();
+  ERR_clear_error();
   ret = SSL_shutdown(ssl);
   caml_acquire_runtime_system();
   switch (ret) {
@@ -1882,7 +1883,6 @@ CAMLprim value ocaml_ssl_shutdown(value socket)
       /* close(SSL_get_fd(SSL_val(socket))); */
       CAMLreturn(Val_int(ret));
     default:
-      ERR_clear_error();
       ret = SSL_get_error(ssl, ret);
       caml_raise_with_arg(*caml_named_value("ssl_exn_connection_error"), Val_int(ret));
   }
@@ -1894,13 +1894,13 @@ CAMLprim value ocaml_ssl_shutdown_blocking(value socket)
   SSL *ssl = SSL_val(socket);
   int ret;
 
+  ERR_clear_error();
   ret = SSL_shutdown(ssl);
   switch (ret) {
     case 0:
     case 1:
       CAMLreturn(Val_int(ret));
     default:
-      ERR_clear_error();
       ret = SSL_get_error(ssl, ret);
       caml_raise_with_arg(*caml_named_value("ssl_exn_connection_error"), Val_int(ret));
   }

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1840,7 +1840,7 @@ CAMLprim value ocaml_ssl_flush(value socket)
     if (ret != 1) {
       caml_acquire_runtime_system();
       caml_raise_with_arg(*caml_named_value("ssl_exn_flush_error"),
-			  Val_bool(BIO_should_retry(bio)));
+			  Val_bool(ret==-1));
     };
   }
   caml_acquire_runtime_system();

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -1480,6 +1480,7 @@ CAMLprim value ocaml_ssl_connect(value socket)
   SSL *ssl = SSL_val(socket);
 
   caml_release_runtime_system();
+  ERR_clear_error();
   ret = SSL_connect(ssl);
   err = SSL_get_error(ssl, ret);
   caml_acquire_runtime_system();
@@ -1495,6 +1496,7 @@ CAMLprim value ocaml_ssl_connect_blocking(value socket)
   int ret, err;
   SSL *ssl = SSL_val(socket);
 
+  ERR_clear_error();
   ret = SSL_connect(ssl);
   err = SSL_get_error(ssl, ret);
   if (err != SSL_ERROR_NONE)
@@ -1596,8 +1598,10 @@ CAMLprim value ocaml_ssl_write(value socket, value buffer, value start, value le
   char *buf = malloc(buflen);
   SSL *ssl = SSL_val(socket);
 
+  if (Int_val(start) < 0) caml_invalid_argument("Ssl.write: negative offset");
+  if (Int_val(length) < 0) caml_invalid_argument("Ssl.write: negative length");
   if (Int_val(start) + Int_val(length) > caml_string_length(buffer))
-    caml_invalid_argument("Buffer too short.");
+    caml_invalid_argument("Ssl.write: Buffer too short.");
 
   memmove(buf, (char*)String_val(buffer) + Int_val(start), buflen);
   caml_release_runtime_system();
@@ -1621,8 +1625,10 @@ CAMLprim value ocaml_ssl_write_blocking(value socket, value buffer, value start,
   char *buf = (char*)String_val(buffer) + Int_val(start);
   SSL *ssl = SSL_val(socket);
 
+  if (Int_val(start) < 0) caml_invalid_argument("Ssl.write: negative offset");
+  if (Int_val(length) < 0) caml_invalid_argument("Ssl.write: negative length");
   if (Int_val(start) + Int_val(length) > caml_string_length(buffer))
-    caml_invalid_argument("Buffer too short.");
+    caml_invalid_argument("Ssl.write: Buffer too short.");
 
   ERR_clear_error();
   ret = SSL_write(ssl, buf, buflen);
@@ -1642,9 +1648,10 @@ CAMLprim value ocaml_ssl_write_bigarray(value socket, value buffer, value start,
   struct caml_ba_array *ba = Caml_ba_array_val(buffer);
   char *buf = ((char *)ba->data) + Int_val(start);
 
-  if(Int_val(start) < 0) caml_invalid_argument("Ssl.write_bigarray: negative offset");
-  if(Int_val(length) < 0) caml_invalid_argument("Ssl.write_bigarray: negative length");
-
+  if (Int_val(start) < 0)
+    caml_invalid_argument("Ssl.write_bigarray: negative offset");
+  if (Int_val(length) < 0)
+    caml_invalid_argument("Ssl.write_bigarray: negative length");
   if (Int_val(start) + Int_val(length) > ba->dim[0])
     caml_invalid_argument("Ssl.write_bigarray: buffer too short.");
 
@@ -1668,9 +1675,10 @@ CAMLprim value ocaml_ssl_write_bigarray_blocking(value socket, value buffer, val
   struct caml_ba_array *ba = Caml_ba_array_val(buffer);
   char *buf = ((char *)ba->data) + Int_val(start);
 
-  if(Int_val(start) < 0) caml_invalid_argument("Ssl.write_bigarray_blocking: negative offset");
-  if(Int_val(length) < 0) caml_invalid_argument("Ssl.write_bigarray_blocking: negative length");
-
+  if (Int_val(start) < 0)
+    caml_invalid_argument("Ssl.write_bigarray: negative offset");
+  if (Int_val(length) < 0)
+    caml_invalid_argument("Ssl.write_bigarray: negative length");
   if (Int_val(start) + Int_val(length) > ba->dim[0])
     caml_invalid_argument("Ssl.write_bigarray: buffer too short.");
 
@@ -1692,8 +1700,10 @@ CAMLprim value ocaml_ssl_read(value socket, value buffer, value start, value len
   char *buf = malloc(buflen);
   SSL *ssl = SSL_val(socket);
 
+  if (Int_val(start) < 0) caml_invalid_argument("Ssl.read: negative offset");
+  if (Int_val(length) < 0) caml_invalid_argument("Ssl.read: negative length");
   if (Int_val(start) + Int_val(length) > caml_string_length(buffer))
-    caml_invalid_argument("Buffer too short.");
+    caml_invalid_argument("Ssl.read: Buffer too short.");
 
   caml_release_runtime_system();
   ERR_clear_error();
@@ -1717,12 +1727,12 @@ CAMLprim value ocaml_ssl_read_blocking(value socket, value buffer, value start, 
   char* buf = ((char*)String_val(buffer)) + Int_val(start);
   SSL *ssl = SSL_val(socket);
 
+  if (Int_val(start) < 0) caml_invalid_argument("Ssl.read: negative offset");
+  if (Int_val(length) < 0) caml_invalid_argument("Ssl.read: negative length");
   if (Int_val(start) + Int_val(length) > caml_string_length(buffer))
-    caml_invalid_argument("Buffer too short.");
+    caml_invalid_argument("Ssl.read: Buffer too short.");
 
   ERR_clear_error();
-
-
   ret = SSL_read(ssl, buf, buflen);
   err = SSL_get_error(ssl, ret);
 
@@ -1740,9 +1750,10 @@ CAMLprim value ocaml_ssl_read_into_bigarray(value socket, value buffer, value st
   char *buf = ((char *)ba->data) + Int_val(start);
   SSL *ssl = SSL_val(socket);
 
-  if(Int_val(start) < 0) caml_invalid_argument("Ssl.read_into_bigarray: negative offset");
-  if(Int_val(length) < 0) caml_invalid_argument("Ssl.read_into_bigarray: negative length");
-
+  if (Int_val(start) < 0)
+    caml_invalid_argument("Ssl.read_into_bigarray: negative offset");
+  if (Int_val(length) < 0)
+    caml_invalid_argument("Ssl.read_into_bigarray: negative length");
   if (Int_val(start) + Int_val(length) > ba->dim[0])
     caml_invalid_argument("Ssl.read_into_bigarray: buffer too short.");
 
@@ -1766,9 +1777,10 @@ CAMLprim value ocaml_ssl_read_into_bigarray_blocking(value socket, value buffer,
   char *buf = ((char *)ba->data) + Int_val(start);
   SSL *ssl = SSL_val(socket);
 
-  if(Int_val(start) < 0) caml_invalid_argument("Ssl.read_into_bigarray: negative offset");
-  if(Int_val(length) < 0) caml_invalid_argument("Ssl.read_into_bigarray: negative length");
-
+  if (Int_val(start) < 0)
+    caml_invalid_argument("Ssl.read_into_bigarray: negative offset");
+  if (Int_val(length) < 0)
+    caml_invalid_argument("Ssl.read_into_bigarray: negative length");
   if (Int_val(start) + Int_val(length) > ba->dim[0])
     caml_invalid_argument("Ssl.read_into_bigarray: buffer too short.");
 
@@ -1870,6 +1882,7 @@ CAMLprim value ocaml_ssl_shutdown(value socket)
       /* close(SSL_get_fd(SSL_val(socket))); */
       CAMLreturn(Val_int(ret));
     default:
+      ERR_clear_error();
       ret = SSL_get_error(ssl, ret);
       caml_raise_with_arg(*caml_named_value("ssl_exn_connection_error"), Val_int(ret));
   }
@@ -1887,6 +1900,7 @@ CAMLprim value ocaml_ssl_shutdown_blocking(value socket)
     case 1:
       CAMLreturn(Val_int(ret));
     default:
+      ERR_clear_error();
       ret = SSL_get_error(ssl, ret);
       caml_raise_with_arg(*caml_named_value("ssl_exn_connection_error"), Val_int(ret));
   }


### PR DESCRIPTION
While working on another PR I spotted 3 bugs (and one security issue)

- access outside of the buffer is possible in Ssl.read and Ssl.write: start sign is not tested
- ERR_clear_error() is missing in 4 places while it is required in the spec
- a missing "_blocking" in my last PR

I don't think 3 separate PR are needed, as it is a small PR, but I can do it if you wish. 