### PR TITLE
Error functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@ Unreleased
   operation with unwritten bytes (#103, #116)
 - Fix calls in C stubs that need to call `ERR_clear_error` before the underlying
   OpenSSL call (#118)
-
+- Add a module `Ssl.Error` to retrieve OpenSSL errors in a structured way (#119)
+  
 0.5.13 (2022-10-20)
 =====
 

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -81,12 +81,19 @@ type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.A
 
 external get_error_string : unit -> string = "ocaml_ssl_get_error_string"
 
-external get_error : unit -> int * string * string = "ocaml_ssl_get_error_struct"
+external error_struct : int -> int * string * string = "ocaml_ssl_error_struct"
 
-external peek_last_error : unit -> int * string * string = "ocaml_ssl_peek_last_error_struct"
+let get_error () =
+  error_struct 0
+
+let peek_error () =
+  error_struct 1
+
+let peek_last_error () =
+  error_struct 2
 
 (** Reproduces the string format from ERR_error_string_n *)
-let peek_error_last_string () =
+let peek_last_error_string () =
   let code, lib, reason = peek_last_error () in
   Printf.sprintf "error:%08lX:%s::%s" (Int32.of_int code) lib reason
 
@@ -119,13 +126,13 @@ let () =
     | Unmatching_keys -> Some ("SSL: Unmatching keys")
     | Invalid_socket -> Some ("SSL: Invalid socket")
     | Handler_error -> Some ("SSL: Handler error")
-    | Connection_error _ -> Some ("SSL connection() error: " ^ (peek_error_last_string()))
-    | Accept_error _ -> Some ("SSL accept() error: " ^ (peek_error_last_string()))
-    | Read_error _ -> Some ("SSL read() error: " ^ (peek_error_last_string()))
-    | Write_error _ -> Some ("SSL write() error: " ^ (peek_error_last_string()))
-    | Verify_error _ -> Some ("SSL verify() error: " ^ (peek_error_last_string()))
+    | Connection_error _ -> Some ("SSL connection() error: " ^ (peek_last_error_string()))
+    | Accept_error _ -> Some ("SSL accept() error: " ^ (peek_last_error_string()))
+    | Read_error _ -> Some ("SSL read() error: " ^ (peek_last_error_string()))
+    | Write_error _ -> Some ("SSL write() error: " ^ (peek_last_error_string()))
+    | Verify_error _ -> Some ("SSL verify() error: " ^ (peek_last_error_string()))
     | Flush_error b -> Some (Printf.sprintf "SSL flush(%b) error: " b
-                             ^ (peek_error_last_string()))
+                             ^ (peek_last_error_string()))
     | _ -> None)
 
 let () =

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -83,11 +83,11 @@ external get_error_string : unit -> string = "ocaml_ssl_get_error_string"
 
 external get_error : unit -> int * string * string = "ocaml_ssl_get_error_struct"
 
-external peek_error_last : unit -> int * string * string = "ocaml_ssl_peek_error_last_struct"
+external peek_last_error : unit -> int * string * string = "ocaml_ssl_peek_last_error_struct"
 
 (** Reproduces the string format from ERR_error_string_n *)
 let peek_error_last_string () =
-  let code, lib, reason = peek_error_last () in
+  let code, lib, reason = peek_last_error () in
   Printf.sprintf "error:%08lX:%s::%s" (Int32.of_int code) lib reason
 
 exception Method_error

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -81,16 +81,18 @@ type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.A
 
 external get_error_string : unit -> string = "ocaml_ssl_get_error_string"
 
-external error_struct : int -> int * string * string = "ocaml_ssl_error_struct"
+type err_function = | Get_error | Peek_error | Peek_last_error
+
+external error_struct : err_function -> int * string * string = "ocaml_ssl_error_struct"
 
 let get_error () =
-  error_struct 0
+  error_struct Get_error
 
 let peek_error () =
-  error_struct 1
+  error_struct Peek_error
 
 let peek_last_error () =
-  error_struct 2
+  error_struct Peek_last_error
 
 (** Reproduces the string format from ERR_error_string_n *)
 let peek_last_error_string () =

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -81,6 +81,15 @@ type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.A
 
 external get_error_string : unit -> string = "ocaml_ssl_get_error_string"
 
+external get_error : unit -> int * string * string = "ocaml_ssl_get_error_struct"
+
+external peek_error_last : unit -> int * string * string = "ocaml_ssl_peek_error_last_struct"
+
+(** Reproduces the string format from ERR_error_string_n *)
+let peek_error_last_string () =
+  let code, lib, reason = peek_error_last () in
+  Printf.sprintf "error:%08lX:%s::%s" (Int32.of_int code) lib reason
+
 exception Method_error
 exception Context_error
 exception Certificate_error of string
@@ -110,13 +119,13 @@ let () =
     | Unmatching_keys -> Some ("SSL: Unmatching keys")
     | Invalid_socket -> Some ("SSL: Invalid socket")
     | Handler_error -> Some ("SSL: Handler error")
-    | Connection_error _ -> Some ("SSL connection() error: " ^ (get_error_string()))
-    | Accept_error _ -> Some ("SSL accept() error: " ^ (get_error_string()))
-    | Read_error _ -> Some ("SSL read() error: " ^ (get_error_string()))
-    | Write_error _ -> Some ("SSL write() error: " ^ (get_error_string()))
-    | Verify_error _ -> Some ("SSL verify() error: " ^ (get_error_string()))
+    | Connection_error _ -> Some ("SSL connection() error: " ^ (peek_error_last_string()))
+    | Accept_error _ -> Some ("SSL accept() error: " ^ (peek_error_last_string()))
+    | Read_error _ -> Some ("SSL read() error: " ^ (peek_error_last_string()))
+    | Write_error _ -> Some ("SSL write() error: " ^ (peek_error_last_string()))
+    | Verify_error _ -> Some ("SSL verify() error: " ^ (peek_error_last_string()))
     | Flush_error b -> Some (Printf.sprintf "SSL flush(%b) error: " b
-                             ^ (get_error_string()))
+                             ^ (peek_error_last_string()))
     | _ -> None)
 
 let () =

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -79,25 +79,31 @@ type verify_error =
 
 type bigarray = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
+(** Kept for backwards compatibility *)
 external get_error_string : unit -> string = "ocaml_ssl_get_error_string"
 
-type err_function = | Get_error | Peek_error | Peek_last_error
+module Error = struct
+  type t = private { code: int; lib: string option; reason: string option }
+  type err_function = | Get_error | Peek_error | Peek_last_error
 
-external error_struct : err_function -> int * string * string = "ocaml_ssl_error_struct"
+  external error_struct : err_function -> t = "ocaml_ssl_error_struct"
 
-let get_error () =
-  error_struct Get_error
+  let get_error () =
+    error_struct Get_error
+  
+  let peek_error () =
+    error_struct Peek_error
+  
+  let peek_last_error () =
+    error_struct Peek_last_error
 
-let peek_error () =
-  error_struct Peek_error
-
-let peek_last_error () =
-  error_struct Peek_last_error
-
-(** Reproduces the string format from ERR_error_string_n *)
-let peek_last_error_string () =
-  let code, lib, reason = peek_last_error () in
-  Printf.sprintf "error:%08lX:%s::%s" (Int32.of_int code) lib reason
+  (** Reproduces the string format from ERR_error_string_n *)
+  let peek_last_error_string () =
+    let err = peek_last_error () in
+    let libstring = Option.value err.lib ~default:"lib(0)" in
+    let reasonstring = Option.value err.reason ~default:"reason(0)" in
+    Printf.sprintf "error:%08lX:%s::%s" (Int32.of_int err.code) libstring reasonstring
+end
 
 exception Method_error
 exception Context_error
@@ -128,13 +134,13 @@ let () =
     | Unmatching_keys -> Some ("SSL: Unmatching keys")
     | Invalid_socket -> Some ("SSL: Invalid socket")
     | Handler_error -> Some ("SSL: Handler error")
-    | Connection_error _ -> Some ("SSL connection() error: " ^ (peek_last_error_string()))
-    | Accept_error _ -> Some ("SSL accept() error: " ^ (peek_last_error_string()))
-    | Read_error _ -> Some ("SSL read() error: " ^ (peek_last_error_string()))
-    | Write_error _ -> Some ("SSL write() error: " ^ (peek_last_error_string()))
-    | Verify_error _ -> Some ("SSL verify() error: " ^ (peek_last_error_string()))
+    | Connection_error _ -> Some ("SSL connection() error: " ^ (Error.peek_last_error_string()))
+    | Accept_error _ -> Some ("SSL accept() error: " ^ (Error.peek_last_error_string()))
+    | Read_error _ -> Some ("SSL read() error: " ^ (Error.peek_last_error_string()))
+    | Write_error _ -> Some ("SSL write() error: " ^ (Error.peek_last_error_string()))
+    | Verify_error _ -> Some ("SSL verify() error: " ^ (Error.peek_last_error_string()))
     | Flush_error b -> Some (Printf.sprintf "SSL flush(%b) error: " b
-                             ^ (peek_last_error_string()))
+                             ^ (Error.peek_last_error_string()))
     | _ -> None)
 
 let () =

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -208,6 +208,10 @@ val get_error_string : unit -> string
     Returns the code and library and reason strings *)
 val get_error : unit -> int * string * string
 
+(** Retrieve the earliest error from the error queue without modifying it.
+    Returns the code and library and reason strings *)
+val peek_error : unit -> int * string * string
+
 (** Retrieves the latest error code from the thread's error queue without
     modifying it. Returns the code and library and reason strings. *)
 val peek_last_error : unit -> int * string * string

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -200,8 +200,8 @@ exception Verify_error of verify_error
     [Ssl_threads.init] first. *)
 val init : ?thread_safe:bool -> unit -> unit
 
-(** Retrieve a human-readable message that corresponds to the last error that
-    occurred. *)
+(** Retrieve a human-readable message that corresponds to the earliest error
+    code from the thread's error queue and removes the entry. *)
 val get_error_string : unit -> string
 
 (** Retrieve the earliest error from the error queue then it removes the entry.
@@ -210,7 +210,7 @@ val get_error : unit -> int * string * string
 
 (** Retrieves the latest error code from the thread's error queue without
     modifying it. Returns the code and library and reason strings. *)
-val peek_error_last : unit -> int * string * string
+val peek_last_error : unit -> int * string * string
 
 (** Protocol used by SSL. *)
 type protocol =

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -203,6 +203,7 @@ val init : ?thread_safe:bool -> unit -> unit
 (** Retrieve a human-readable message that corresponds to the earliest error
     code from the thread's error queue and removes the entry. *)
 val get_error_string : unit -> string
+  [@@ocaml.alert deprecated "Use [Ssl.Error.get_error] instead"]
 
 module Error: sig
     type t = private { code: int; lib: string option; reason: string option }

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -204,6 +204,14 @@ val init : ?thread_safe:bool -> unit -> unit
     occurred. *)
 val get_error_string : unit -> string
 
+(** Retrieve the earliest error from the error queue then it removes the entry.
+    Returns the code and library and reason strings *)
+val get_error : unit -> int * string * string
+
+(** Retrieves the latest error code from the thread's error queue without
+    modifying it. Returns the code and library and reason strings. *)
+val peek_error_last : unit -> int * string * string
+
 (** Protocol used by SSL. *)
 type protocol =
   | SSLv23 (** accept all possible protocols (SSLv2 if supported by openssl,

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -204,17 +204,21 @@ val init : ?thread_safe:bool -> unit -> unit
     code from the thread's error queue and removes the entry. *)
 val get_error_string : unit -> string
 
-(** Retrieve the earliest error from the error queue then it removes the entry.
-    Returns the code and library and reason strings *)
-val get_error : unit -> int * string * string
+module Error: sig
+    type t = private { code: int; lib: string option; reason: string option }
 
-(** Retrieve the earliest error from the error queue without modifying it.
-    Returns the code and library and reason strings *)
-val peek_error : unit -> int * string * string
+    (** Retrieve the earliest error from the error queue then it removes the entry.
+        Returns the code and library and reason strings *)
+    val get_error : unit -> t
 
-(** Retrieves the latest error code from the thread's error queue without
-    modifying it. Returns the code and library and reason strings. *)
-val peek_last_error : unit -> int * string * string
+    (** Retrieve the earliest error from the error queue without modifying it.
+        Returns the code and library and reason strings *)
+    val peek_error : unit -> t
+
+    (** Retrieves the latest error code from the thread's error queue without
+        modifying it. Returns the code and library and reason strings. *)
+    val peek_last_error : unit -> t
+end
 
 (** Protocol used by SSL. *)
 type protocol =

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -263,36 +263,22 @@ CAMLprim value ocaml_ssl_get_error_string(value unit)
   CAMLreturn(caml_copy_string(buf));
 }
 
-CAMLprim value ocaml_ssl_get_error_struct(value unit)
+CAMLprim value ocaml_ssl_error_struct(value err_func)
 {
-  CAMLparam1(unit);
+  CAMLparam1(err_func);
   CAMLlocal3(result, libstring, reasonstring);
-  unsigned long code = ERR_get_error();
-  result = caml_alloc_tuple(3);
-  const char *lib = ERR_lib_error_string(code);
-  const char *reason = ERR_reason_error_string(code);
-  if (lib != NULL) {
-    libstring = caml_copy_string(lib);
-  } else {
-    libstring = caml_copy_string("lib(0)");
+  unsigned long code = 0;
+  switch(Int_val(err_func)) {
+    case 0:
+      code = ERR_get_error();
+      break;
+    case 1:
+      code = ERR_peek_error();
+      break;
+    case 2:
+      code = ERR_peek_last_error();
+      break;
   }
-  if (reason != NULL) {
-    reasonstring = caml_copy_string(reason);
-  } else {
-    reasonstring = caml_copy_string("reason(0)");
-  }
-  Store_field(result, 0, Val_int(code));
-  Store_field(result, 1, libstring);
-  Store_field(result, 2, reasonstring);
-
-  CAMLreturn(result);
-}
-
-CAMLprim value ocaml_ssl_peek_last_error_struct(value unit)
-{
-  CAMLparam1(unit);
-  CAMLlocal3(result, libstring, reasonstring);
-  unsigned long code = ERR_peek_last_error();
   result = caml_alloc_tuple(3);
   const char *lib = ERR_lib_error_string(code);
   const char *reason = ERR_reason_error_string(code);

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -109,6 +109,19 @@ static struct custom_operations socket_ops =
   custom_deserialize_default
 };
 
+/* Option types */
+
+#define Val_none Val_int(0)
+
+static value Val_some(value v)
+{
+  CAMLparam1(v);
+  CAMLlocal1(some);
+  some = caml_alloc(1, 0);
+  Store_field(some, 0, v);
+  CAMLreturn(some);
+}
+
 /******************
  * Initialization *
  ******************/
@@ -269,12 +282,12 @@ CAMLprim value ocaml_ssl_error_struct(value err_func)
   const char *lib = ERR_lib_error_string(code);
   const char *reason = ERR_reason_error_string(code);
   if (lib != NULL) {
-    libval = caml_alloc_some(caml_copy_string(lib));
+    libval = Val_some(caml_copy_string(lib));
   } else {
     libval = Val_none;
   }
   if (reason != NULL) {
-    reasonval = caml_alloc_some(caml_copy_string(reason));
+    reasonval = Val_some(caml_copy_string(reason));
   } else {
     reasonval = Val_none;
   }
@@ -1476,7 +1489,7 @@ CAMLprim value ocaml_ssl_get_negotiated_alpn_protocol(value socket)
   proto = caml_alloc_string (len);
   memcpy((char *)String_val(proto), (const char*)data, len);
 
-  CAMLreturn(caml_alloc_some(proto));
+  CAMLreturn(Val_some(proto));
 }
 #else
 CAMLprim value ocaml_ssl_set_alpn_protos(value socket, value vprotos)

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <assert.h>
 
+#define CAML_NAME_SPACE
 #include <caml/alloc.h>
 #include <caml/callback.h>
 #include <caml/custom.h>
@@ -262,7 +263,55 @@ CAMLprim value ocaml_ssl_get_error_string(value unit)
   CAMLreturn(caml_copy_string(buf));
 }
 
+CAMLprim value ocaml_ssl_get_error_struct(value unit)
+{
+  CAMLparam1(unit);
+  unsigned long code = ERR_get_error();
+  CAMLlocal3(result, libstring, reasonstring);
+  result = caml_alloc_tuple(3);
+  const char *lib = ERR_lib_error_string(code);
+  const char *reason = ERR_reason_error_string(code);
+  if (lib != NULL) {
+    libstring = caml_copy_string(lib);
+  } else {
+    libstring = caml_copy_string("lib(0)");
+  }
+  if (reason != NULL) {
+    reasonstring = caml_copy_string(reason);
+  } else {
+    reasonstring = caml_copy_string("reason(0)");
+  }
+  Store_field(result, 0, Val_int(code));
+  Store_field(result, 1, libstring);
+  Store_field(result, 2, reasonstring);
 
+  CAMLreturn(result);
+}
+
+CAMLprim value ocaml_ssl_peek_error_last_struct(value unit)
+{
+  CAMLparam1(unit);
+  unsigned long code = ERR_peek_last_error();
+  CAMLlocal3(result, libstring, reasonstring);
+  result = caml_alloc_tuple(3);
+  const char *lib = ERR_lib_error_string(code);
+  const char *reason = ERR_reason_error_string(code);
+  if (lib != NULL) {
+    libstring = caml_copy_string(lib);
+  } else {
+    libstring = caml_copy_string("lib(0)");
+  }
+  if (reason != NULL) {
+    reasonstring = caml_copy_string(reason);
+  } else {
+    reasonstring = caml_copy_string("reason(0)");
+  }
+  Store_field(result, 0, Val_int(code));
+  Store_field(result, 1, libstring);
+  Store_field(result, 2, reasonstring);
+
+  CAMLreturn(result);
+}
 /*****************************
  * Context-related functions *
  *****************************/

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -288,7 +288,7 @@ CAMLprim value ocaml_ssl_get_error_struct(value unit)
   CAMLreturn(result);
 }
 
-CAMLprim value ocaml_ssl_peek_error_last_struct(value unit)
+CAMLprim value ocaml_ssl_peek_last_error_struct(value unit)
 {
   CAMLparam1(unit);
   CAMLlocal3(result, libstring, reasonstring);

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -266,8 +266,8 @@ CAMLprim value ocaml_ssl_get_error_string(value unit)
 CAMLprim value ocaml_ssl_get_error_struct(value unit)
 {
   CAMLparam1(unit);
-  unsigned long code = ERR_get_error();
   CAMLlocal3(result, libstring, reasonstring);
+  unsigned long code = ERR_get_error();
   result = caml_alloc_tuple(3);
   const char *lib = ERR_lib_error_string(code);
   const char *reason = ERR_reason_error_string(code);

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -291,8 +291,8 @@ CAMLprim value ocaml_ssl_get_error_struct(value unit)
 CAMLprim value ocaml_ssl_peek_error_last_struct(value unit)
 {
   CAMLparam1(unit);
-  unsigned long code = ERR_peek_last_error();
   CAMLlocal3(result, libstring, reasonstring);
+  unsigned long code = ERR_peek_last_error();
   result = caml_alloc_tuple(3);
   const char *lib = ERR_lib_error_string(code);
   const char *reason = ERR_reason_error_string(code);

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -109,20 +109,6 @@ static struct custom_operations socket_ops =
   custom_deserialize_default
 };
 
-/* Option types */
-
-#define Val_none Val_int(0)
-
-static value Val_some(value v)
-{
-  CAMLparam1(v);
-  CAMLlocal1(some);
-  some = caml_alloc(1, 0);
-  Store_field(some, 0, v);
-  CAMLreturn(some);
-}
-
-
 /******************
  * Initialization *
  ******************/
@@ -266,7 +252,7 @@ CAMLprim value ocaml_ssl_get_error_string(value unit)
 CAMLprim value ocaml_ssl_error_struct(value err_func)
 {
   CAMLparam1(err_func);
-  CAMLlocal3(result, libstring, reasonstring);
+  CAMLlocal3(result, libval, reasonval);
   unsigned long code = 0;
   switch(Int_val(err_func)) {
     case 0:
@@ -283,18 +269,18 @@ CAMLprim value ocaml_ssl_error_struct(value err_func)
   const char *lib = ERR_lib_error_string(code);
   const char *reason = ERR_reason_error_string(code);
   if (lib != NULL) {
-    libstring = caml_copy_string(lib);
+    libval = caml_alloc_some(caml_copy_string(lib));
   } else {
-    libstring = caml_copy_string("lib(0)");
+    libval = Val_none;
   }
   if (reason != NULL) {
-    reasonstring = caml_copy_string(reason);
+    reasonval = caml_alloc_some(caml_copy_string(reason));
   } else {
-    reasonstring = caml_copy_string("reason(0)");
+    reasonval = Val_none;
   }
   Store_field(result, 0, Val_int(code));
-  Store_field(result, 1, libstring);
-  Store_field(result, 2, reasonstring);
+  Store_field(result, 1, libval);
+  Store_field(result, 2, reasonval);
 
   CAMLreturn(result);
 }
@@ -1490,7 +1476,7 @@ CAMLprim value ocaml_ssl_get_negotiated_alpn_protocol(value socket)
   proto = caml_alloc_string (len);
   memcpy((char *)String_val(proto), (const char*)data, len);
 
-  CAMLreturn(Val_some(proto));
+  CAMLreturn(caml_alloc_some(proto));
 }
 #else
 CAMLprim value ocaml_ssl_set_alpn_protos(value socket, value vprotos)

--- a/tests/ssl_comm.ml
+++ b/tests/ssl_comm.ml
@@ -1,6 +1,23 @@
 open Alcotest
-let test_init () = 
-    Ssl.init () |> ignore
+open Ssl
+let test_init () =
+    init () |> ignore
+
+let test_error_queue () =
+  let context = Ssl.create_context TLSv1_3 Client_context in
+  try use_certificate context "expired.pem" "" with | _ -> ();
+  let code, lib, reason = peek_error_last () in
+  check int "Error code" 168296450 code;
+  check string "Library string" "SSL routines" lib;
+  check string "Reason string" "system lib" reason;
+  let code, lib, reason = get_error () in
+  check int "Error code" 268959746 code;
+  check string "Library string" "BIO routines" lib;
+  check string "Reason string" "system lib" reason;
+  let code, lib, reason = get_error () in
+  check int "Error code" 168296450 code;
+  check string "Library string" "SSL routines" lib;
+  check string "Reason string" "system lib" reason
 
 let () =
   Alcotest.run "Ssl communication"
@@ -8,5 +25,6 @@ let () =
       ( "Communication",
         [
           test_case "Test init" `Quick test_init;
+          test_case "Test peek_error_last" `Quick test_error_queue;
         ] );
     ]

--- a/tests/ssl_comm.ml
+++ b/tests/ssl_comm.ml
@@ -6,6 +6,10 @@ let test_init () =
 let test_error_queue () =
   let context = Ssl.create_context TLSv1_3 Client_context in
   try use_certificate context "expired.pem" "" with | _ -> ();
+  let code, lib, reason = peek_error () in
+  check int "Error code" 268959746 code;
+  check string "Library string" "BIO routines" lib;
+  check string "Reason string" "system lib" reason;
   let code, lib, reason = peek_last_error () in
   check int "Error code" 168296450 code;
   check string "Library string" "SSL routines" lib;

--- a/tests/ssl_comm.ml
+++ b/tests/ssl_comm.ml
@@ -6,22 +6,22 @@ let test_init () =
 let test_error_queue () =
   let context = Ssl.create_context TLSv1_3 Client_context in
   try use_certificate context "expired.pem" "" with | _ -> ();
-  let code, lib, reason = peek_error () in
-  check int "Error code" 268959746 code;
-  check string "Library string" "BIO routines" lib;
-  check string "Reason string" "system lib" reason;
-  let code, lib, reason = peek_last_error () in
-  check int "Error code" 168296450 code;
-  check string "Library string" "SSL routines" lib;
-  check string "Reason string" "system lib" reason;
-  let code, lib, reason = get_error () in
-  check int "Error code" 268959746 code;
-  check string "Library string" "BIO routines" lib;
-  check string "Reason string" "system lib" reason;
-  let code, lib, reason = get_error () in
-  check int "Error code" 168296450 code;
-  check string "Library string" "SSL routines" lib;
-  check string "Reason string" "system lib" reason
+  let err = Error.peek_error () in
+  check int "Error code" 268959746 err.code;
+  check string "Library string" "BIO routines" (Option.get err.lib);
+  check string "Reason string" "system lib" (Option.get err.reason);
+  let err = Error.peek_last_error () in
+  check int "Error code" 168296450 err.code;
+  check string "Library string" "SSL routines" (Option.get err.lib);
+  check string "Reason string" "system lib" (Option.get err.reason);
+  let err = Error.get_error () in
+  check int "Error code" 268959746 err.code;
+  check string "Library string" "BIO routines" (Option.get err.lib);
+  check string "Reason string" "system lib" (Option.get err.reason);
+  let err = Error.get_error () in
+  check int "Error code" 168296450 err.code;
+  check string "Library string" "SSL routines" (Option.get err.lib);
+  check string "Reason string" "system lib" (Option.get err.reason)
 
 let () =
   Alcotest.run "Ssl communication"
@@ -29,6 +29,6 @@ let () =
       ( "Communication",
         [
           test_case "Test init" `Quick test_init;
-          test_case "Test peek_error_last" `Quick test_error_queue;
+          test_case "Test error queue" `Quick test_error_queue;
         ] );
     ]

--- a/tests/ssl_comm.ml
+++ b/tests/ssl_comm.ml
@@ -6,7 +6,7 @@ let test_init () =
 let test_error_queue () =
   let context = Ssl.create_context TLSv1_3 Client_context in
   try use_certificate context "expired.pem" "" with | _ -> ();
-  let code, lib, reason = peek_error_last () in
+  let code, lib, reason = peek_last_error () in
   check int "Error code" 168296450 code;
   check string "Library string" "SSL routines" lib;
   check string "Reason string" "system lib" reason;

--- a/tests/ssl_io.ml
+++ b/tests/ssl_io.ml
@@ -1,6 +1,6 @@
 open Alcotest
 
-let test_verify () = 
+let test_verify () =
   let addr = Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", 1342) in
   Util.server_thread addr None |> ignore;
 


### PR DESCRIPTION
This PR should solve  #108

* Bindings for ERR_get_error and ERR_peek_last_error that return the raw errors as a tuple
* Replaces the function used for exceptions with last_error so it doesn't pop the error queue inadvertently

For compatibility I have reproduced the behavior of the function used to print exceptions with the ERR_error_string_n but with the functionality of the ERR_peek_last_error  function (peeks the last error)
