### PR TITLE
fix: warning about incompatible pointers

### DIFF
--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -838,7 +838,7 @@ CAMLprim value caml_alpn_select_cb(SSL *ssl,
 
   selected_protocol = Field(selected_protocol_opt, 0);
   len = caml_string_length(selected_protocol);
-  *out = String_val(selected_protocol);
+  *out = (const unsigned char*) String_val(selected_protocol);
   *outlen = len;
 
   CAMLreturn(SSL_TLSEXT_ERR_OK);


### PR DESCRIPTION
Looks like the warning is only present in the macOS logs, but in any case:

```
ssl_stubs.c:841:8: warning: assigning to 'const unsigned char *' from 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]
  *out = String_val(selected_protocol);
       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```