### PR TITLE
chore: exclude ocamlformat commit from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Ran ocamlformat for the first time on the codebase
+15189ac5559523505076886bf0943b093d702666
+


### PR DESCRIPTION
Excludes https://github.com/savonet/ocaml-ssl/commit/15189ac5559523505076886bf0943b093d702666 from `git blame` as per https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view