### PR TITLE
refactor: clean up conditional compilation related to TLS 1.3 detection

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -13,26 +13,6 @@ let default c : C.Pkg_config.package_conf =
     else { libs = [ "-L/opt/local/lib" ]; cflags = [ "-I/opt/local/include" ] }
   else { libs = [ "-lssl"; "-lcrypto" ]; cflags = [] }
 
-let prog fun_name =
-  Printf.sprintf
-    {c|
-#include <openssl/ssl.h>
-int main(int argc, char **argv) {
-  void *foo = %s;
-  return 0;
-}|c}
-    fun_name
-
-let function_tests =
-  [ "TLSv1_1_method", "HAVE_TLS11"
-  ; "TLSv1_2_method", "HAVE_TLS12"
-  ; "EC_KEY_free", "HAVE_EC"
-  ; "SSL_set_alpn_protos", "HAVE_ALPN"
-  ; "ASN1_TIME_to_tm", "HAVE_ASN1_TIME_TO_TM"
-  ]
-
-let macro_tests = [ "SSL_set_tlsext_host_name", "HAVE_SNI" ]
-
 let () =
   C.main ~name:"ssl" (fun c ->
       let default = default c in
@@ -44,30 +24,5 @@ let () =
           | Some s -> s
           | None -> default)
       in
-      let results =
-        C.C_define.import
-          c
-          ~c_flags:conf.cflags
-          ~includes:[ "openssl/ssl.h" ]
-          (List.map (fun (c, _) -> c, C.C_define.Type.Switch) macro_tests)
-      in
-      let defines =
-        List.combine macro_tests results
-        |> List.map (fun ((name, const), (name', value)) ->
-               assert (name = name');
-               const, value)
-      in
-      let defines =
-        List.fold_left
-          (fun acc (fun_name, var_name) ->
-            let defined =
-              prog fun_name
-              |> C.c_test c ~c_flags:conf.cflags ~link_flags:conf.libs
-            in
-            (var_name, C.C_define.Value.Switch defined) :: acc)
-          defines
-          function_tests
-      in
-      C.C_define.gen_header_file c ~fname:"ocaml_ssl.h" defines;
       C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
       C.Flags.write_sexp "c_flags.sexp" conf.cflags)

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -31,10 +31,7 @@ let function_tests =
   ; "ASN1_TIME_to_tm", "HAVE_ASN1_TIME_TO_TM"
   ]
 
-let macro_tests =
-  [ "SSL_set_tlsext_host_name", "HAVE_SNI"
-  ; "SSL_EXT_TLS1_3_ONLY", "HAVE_TLS13"
-  ]
+let macro_tests = [ "SSL_set_tlsext_host_name", "HAVE_SNI" ]
 
 let () =
   C.main ~name:"ssl" (fun c ->

--- a/src/dune
+++ b/src/dune
@@ -14,6 +14,6 @@
   (backend bisect_ppx)))
 
 (rule
- (targets c_flags.sexp c_library_flags.sexp ocaml_ssl.h)
+ (targets c_flags.sexp c_library_flags.sexp)
  (action
   (run ./config/discover.exe)))

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -290,21 +290,16 @@ static int protocol_flags[] = {SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3,
 #ifdef HAVE_TLS11
                                SSL_OP_NO_TLSv1_1
 #else
-    0 /* not supported, nothing to disable */
+                               0 /* not supported, nothing to disable */
 #endif
                                ,
 #ifdef HAVE_TLS12
                                SSL_OP_NO_TLSv1_2
 #else
-    0 /* not supported ,nothing to disable */
+                               0 /* not supported ,nothing to disable */
 #endif
                                ,
-#ifdef HAVE_TLS13
-                               SSL_OP_NO_TLSv1_3
-#else
-    0 /* not supported, nothing to disable */
-#endif
-};
+                               SSL_OP_NO_TLSv1_3};
 
 static const SSL_METHOD *get_method(int type) {
   const SSL_METHOD *method = NULL;
@@ -351,11 +346,9 @@ static int ocaml_ssl_version_of_tls_version(int tls_version) {
     ret = 4;
     break;
 
-#ifdef HAVE_TLS13
   case TLS1_3_VERSION:
     ret = 5;
     break;
-#endif
 
   default:
     ret = -1;
@@ -385,11 +378,9 @@ static int tls_version_of_ocaml_ssl_version(int ocaml_ssl_version) {
     ret = TLS1_2_VERSION;
     break;
 
-#ifdef HAVE_TLS13
   case 5:
     ret = TLS1_3_VERSION;
     break;
-#endif
 
   default:
     ret = -1;
@@ -482,11 +473,7 @@ value ocaml_ssl_ctx_get_max_proto_version(value context) {
 /* This function assumes the runtime lock is released. In case of failure, it
  * acquires the runtime lock and then raises an OCaml exception. */
 static void set_protocol(SSL_CTX *ssl_context, int protocol) {
-#ifdef HAVE_TLS13
   int max_proto = TLS1_3_VERSION;
-#else
-  int max_proto = TLS1_2_VERSION;
-#endif
   switch (protocol) {
   case 0:
     if (!SSL_CTX_set_min_proto_version(ssl_context, SSL3_VERSION) ||
@@ -529,16 +516,11 @@ static void set_protocol(SSL_CTX *ssl_context, int protocol) {
     break;
 
   case 5:
-#ifdef HAVE_TLS13
     if (!SSL_CTX_set_min_proto_version(ssl_context, TLS1_3_VERSION) ||
         !SSL_CTX_set_max_proto_version(ssl_context, TLS1_3_VERSION)) {
       caml_acquire_runtime_system();
       caml_invalid_argument("Failed to set protocol to TLSv1_3");
     }
-#else
-    caml_acquire_runtime_system();
-    caml_invalid_argument("TLSv1_3 is unsupported");
-#endif
     break;
 
   default:


### PR DESCRIPTION
- since #121 we assume a lower bound of OpenSSL 1.1.1, which has TLS 1.3