### PR TITLE
work on error code: separate lib and reason

### DIFF
--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -85,7 +85,8 @@ external get_error_string : unit -> string = "ocaml_ssl_get_error_string"
 
 module Error = struct
   type t = private
-    { code : int
+    { lib_code : int
+    ; reason_code : int
     ; lib : string option
     ; reason : string option
     }
@@ -107,8 +108,9 @@ module Error = struct
     let libstring = Option.value err.lib ~default:"lib(0)" in
     let reasonstring = Option.value err.reason ~default:"reason(0)" in
     Printf.sprintf
-      "error:%08lX:%s::%s"
-      (Int32.of_int err.code)
+      "error:%02lX:%06lX:%s::%s"
+      (Int32.of_int err.lib_code)
+      (Int32.of_int err.reason_code)
       libstring
       reasonstring
 end

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -223,7 +223,8 @@ val get_error_string : unit -> string
 
 module Error : sig
   type t = private
-    { code : int
+    { lib_code : int
+    ; reason_code : int
     ; lib : string option
     ; reason : string option
     }

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -274,9 +274,14 @@ CAMLprim value ocaml_ssl_error_struct(value err_func) {
   } else {
     reasonval = Val_none;
   }
-  Store_field(result, 0, Val_int(code));
-  Store_field(result, 1, libval);
-  Store_field(result, 2, reasonval);
+  Store_field(result, 0, Val_int(ERR_GET_LIB(code)));
+#if OPENSSL_VERSION_MAJOR < 3
+  Store_field(result, 1, Val_int(ERR_GET_REASON(code) | ERR_GET_FUNC(code)));
+#else
+  Store_field(result, 1, Val_int(ERR_GET_REASON(code)));
+#endif
+  Store_field(result, 2, libval);
+  Store_field(result, 3, reasonval);
 
   CAMLreturn(result);
 }

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -261,7 +261,7 @@ CAMLprim value ocaml_ssl_error_struct(value err_func) {
     code = ERR_peek_last_error();
     break;
   }
-  result = caml_alloc_tuple(3);
+  result = caml_alloc_tuple(4);
   const char *lib = ERR_lib_error_string(code);
   const char *reason = ERR_reason_error_string(code);
   if (lib != NULL) {

--- a/src/ssl_stubs.c
+++ b/src/ssl_stubs.c
@@ -275,10 +275,10 @@ CAMLprim value ocaml_ssl_error_struct(value err_func) {
     reasonval = Val_none;
   }
   Store_field(result, 0, Val_int(ERR_GET_LIB(code)));
-#if OPENSSL_VERSION_MAJOR < 3
-  Store_field(result, 1, Val_int(ERR_GET_REASON(code) | ERR_GET_FUNC(code)));
-#else
+#ifdef OPENSSL_VERSION_MAJOR
   Store_field(result, 1, Val_int(ERR_GET_REASON(code)));
+#else
+  Store_field(result, 1, Val_int(ERR_GET_REASON(code) | ERR_GET_FUNC(code)));
 #endif
   Store_field(result, 2, libval);
   Store_field(result, 3, reasonval);

--- a/tests/ssl_comm.ml
+++ b/tests/ssl_comm.ml
@@ -9,19 +9,19 @@ let test_error_queue () =
   | _ ->
     ();
     let err = Error.peek_error () in
-    check int "Error code" 268959746 err.code;
+    check int "Error code" 32 err.lib_code;
     check string "Library string" "BIO routines" (Option.get err.lib);
     check string "Reason string" "system lib" (Option.get err.reason);
     let err = Error.peek_last_error () in
-    check int "Error code" 168296450 err.code;
+    check int "Error code" 20 err.lib_code;
     check string "Library string" "SSL routines" (Option.get err.lib);
     check string "Reason string" "system lib" (Option.get err.reason);
     let err = Error.get_error () in
-    check int "Error code" 268959746 err.code;
+    check int "Error code" 32 err.lib_code;
     check string "Library string" "BIO routines" (Option.get err.lib);
     check string "Reason string" "system lib" (Option.get err.reason);
     let err = Error.get_error () in
-    check int "Error code" 168296450 err.code;
+    check int "Error code" 20 err.lib_code;
     check string "Library string" "SSL routines" (Option.get err.lib);
     check string "Reason string" "system lib" (Option.get err.reason)
 

--- a/tests/ssl_io.ml
+++ b/tests/ssl_io.ml
@@ -19,7 +19,7 @@ let test_verify () =
     "no verify errors"
     true
     (Str.search_forward
-       (Str.regexp_string "error:00000000:lib(0)")
+       (Str.regexp_string "error:00:000000:lib(0)")
        verify_result
        0
     > 0)
@@ -48,7 +48,7 @@ let test_set_host () =
     "no verify errors"
     true
     (Str.search_forward
-       (Str.regexp_string "error:00000000:lib(0)")
+       (Str.regexp_string "error:00:000000:lib(0)")
        verify_result
        0
     > 0)


### PR DESCRIPTION
on 1.1.1, keep function code inside reason as it has been removed in 3.0