### PR TITLE
Move ssl version test to a github action specific target, execute this target in the CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,10 @@ jobs:
       run: opam install .
     - name: Build and test
       if: ${{ matrix.setup.runtest }}
-      run: opam install -t .
+      run: |
+        opam install -t .
+        eval $(opam env)
+        dune build @github_action_tests
 
   nix-build:
     runs-on: ${{ matrix.setup.os }}

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,8 @@
+(alias
+ (name github_action_tests)
+ (deps
+  (alias_rec runtest)))
+
 (library
  (name util)
  (modules util)
@@ -13,6 +18,16 @@
  (name ssl_comm)
  (modules ssl_comm)
  (libraries ssl alcotest))
+
+(executable
+ (name ssl_version)
+ (modules ssl_version)
+ (libraries ssl alcotest))
+
+(rule
+ (alias github_action_tests)
+ (action
+  (run ./ssl_version.exe)))
 
 (test
  (name ssl_context)

--- a/tests/ssl_comm.ml
+++ b/tests/ssl_comm.ml
@@ -25,23 +25,11 @@ let test_error_queue () =
     check string "Library string" "SSL routines" (Option.get err.lib);
     check string "Reason string" "system lib" (Option.get err.reason)
 
-let test_version () =
-  let ch = Unix.open_process_in "openssl version" in
-  let m, n, p =
-    Scanf.(bscanf (Scanning.from_channel ch)) "OpenSSL %d.%d.%d" (fun x y z ->
-        x, y, z)
-  in
-  Unix.close_process_in ch |> ignore;
-  check int "major" m Ssl.native_library_version.major;
-  check int "minor" n Ssl.native_library_version.minor;
-  check int "patch" p Ssl.native_library_version.patch
-
 let () =
   Alcotest.run
     "Ssl communication"
     [ ( "Communication"
       , [ test_case "Test init" `Quick test_init
-        ; test_case "Test version" `Quick test_version
         ; test_case "Test error queue" `Quick test_error_queue
         ] )
     ]

--- a/tests/ssl_version.ml
+++ b/tests/ssl_version.ml
@@ -1,0 +1,27 @@
+open Alcotest
+open Ssl
+
+let test_init () = init () |> ignore
+
+(* This test is not super robust b/c `openssl` might not be installed or
+   installed but linked to a different shared libary. For this reason, this test
+   is only run in our internal github action CI. *)
+let test_version () =
+  let ch = Unix.open_process_in "openssl version" in
+  let m, n, p =
+    Scanf.(bscanf (Scanning.from_channel ch)) "OpenSSL %d.%d.%d" (fun x y z ->
+        x, y, z)
+  in
+  Unix.close_process_in ch |> ignore;
+  check int "major" m Ssl.native_library_version.major;
+  check int "minor" n Ssl.native_library_version.minor;
+  check int "patch" p Ssl.native_library_version.patch
+
+let () =
+  Alcotest.run
+    "Ssl version"
+    [ ( "Version"
+      , [ test_case "Test init" `Quick test_init
+        ; test_case "Test version" `Quick test_version
+        ] )
+    ]


### PR DESCRIPTION
This addresses the suggestion from https://github.com/ocaml/opam-repository/pull/24102#issuecomment-1636805651