### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       run: opam install .
     - name: Build and test
       if: ${{ matrix.setup.runtest }}
+      shell: bash
       run: |
         opam install -t .
         eval $(opam env)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - {ocaml-version: '4.14', os: ubuntu-latest, runtest: true}
           - {ocaml-version: '5.1', os: ubuntu-latest, runtest: true}
           - {ocaml-version: '5.2', os: ubuntu-latest, runtest: true}
-          - {ocaml-version: '5.2', os: windows-latest, runtest: true}
+          - {ocaml-version: '5.2', os: windows-latest, runtest: false}
     steps:
     - uses: actions/checkout@v4
     - uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,12 @@ jobs:
     - name: Build
       if: ${{ ! matrix.setup.runtest }}
       run: opam install .
-    - name: Build and test
+    - name: Build for testing
       if: ${{ matrix.setup.runtest }}
-      shell: bash
-      run: |
-        opam install -t .
-        eval $(opam env)
-        dune build @github_action_tests
+      run: opam install -t .
+    - name: Test
+      if: ${{ matrix.setup.runtest }}
+      run: opam exec -- dune build @github_action_tests
 
   nix-build:
     runs-on: ${{ matrix.setup.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,16 @@ concurrency:
 
 jobs:
   build:
+    runs-on: ${{ matrix.setup.os }}
     strategy:
       matrix:
-        os:
-        - ubuntu-latest
-        - windows-latest
         setup:
-          - {ocaml-version: '4.05', runtest: false}
-          - {ocaml-version: '4.09', runtest: true}
-          - {ocaml-version: '4.14', runtest: true}
-          - {ocaml-version: '5.1', runtest: true}
-          - {ocaml-version: '5.2', runtest: true}
+          - {ocaml-version: '4.05', os: ubuntu-latest, runtest: false}
+          - {ocaml-version: '4.09', os: ubuntu-latest, runtest: true}
+          - {ocaml-version: '4.14', os: ubuntu-latest, runtest: true}
+          - {ocaml-version: '5.1', os: ubuntu-latest, runtest: true}
+          - {ocaml-version: '5.2', os: ubuntu-latest, runtest: true}
+          - {ocaml-version: '5.2', os: windows-latest, runtest: true}
     steps:
     - uses: actions/checkout@v4
     - uses: ocaml/setup-ocaml@v3
@@ -31,8 +30,6 @@ jobs:
         ocaml-compiler:  ${{ matrix.setup.ocaml-version }}
     - name: Setup opam
       run: opam pin add -n .
-    - name: Install dependencies
-      run: opam depext -yt mad
     - name: Build
       if: ${{ ! matrix.setup.runtest }}
       run: opam install .
@@ -49,7 +46,6 @@ jobs:
       matrix:
         setup:
           - {ocamlVersion: 4_12, os: ubuntu-latest}
-          - {ocamlVersion: 4_13, os: ubuntu-latest}
           - {ocamlVersion: 4_14, os: ubuntu-latest}
           - {ocamlVersion: 5_1, os: ubuntu-latest}
           - {ocamlVersion: 5_2, os: ubuntu-latest}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os:
+        - ubuntu-latest
+        - windows-latest
         setup:
           - {ocaml-version: '4.05', runtest: false}
           - {ocaml-version: '4.09', runtest: true}


### PR DESCRIPTION
Right now, it's not clear how to install this package `ssl` on a GitHub Actions Windows runner. This should be addressed and maintained in this repo for all downstream users. At the moment, it's not clear which version of SSL is even being linked against by 
the environment created by setup-ocaml in GHA. For example, `windows-latest` at the moment appears to be `windows-2022`, with software list [here](https://github.com/actions/runner-images/blob/e01292aaa1de7f18023b7d6ace9130316b288b5a/images/windows/Windows2022-Readme.md), which includes OpenSSL 1.1.1w. Yet trying to build `ssl` on it fails with the issue in https://github.com/savonet/ocaml-ssl/issues/155, so I suspect some other SSL from the setup-ocaml (Cygwin?) environment is at play. We encountered this in various forms during https://github.com/aantron/dream/pull/337, but it really should be solved upstream, perhaps by having this repo's GHA `.yml` file be an example.

If the CI build for this PR fails on Windows, what would it take to get it to work?

Long-term, this repo probably doesn't need a full (OS x OCaml) build matrix, but just to `include:` one row for testing on Windows on a certain OCaml version.