### PR TITLE
test: tidy up tests, disable some tests on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - {ocaml-version: '4.14', os: ubuntu-latest, runtest: true}
           - {ocaml-version: '5.1', os: ubuntu-latest, runtest: true}
           - {ocaml-version: '5.2', os: ubuntu-latest, runtest: true}
-          - {ocaml-version: '5.2', os: windows-latest, runtest: false}
+          - {ocaml-version: '5.2', os: windows-latest, runtest: true}
     steps:
     - uses: actions/checkout@v4
     - uses: ocaml/setup-ocaml@v3

--- a/tests/dune
+++ b/tests/dune
@@ -27,7 +27,9 @@
   server.key
   server.pem
   ca.pem
-  ca.key))
+  ca.key)
+ (enabled_if
+  (<> %{os_type} "Win32")))
 
 (tests
  (names ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
@@ -41,6 +43,4 @@
   server.key
   server.pem
   ca.pem
-  ca.key)
- (enabled_if
-  (<> %{os_type} "Win32")))
+  ca.key))

--- a/tests/dune
+++ b/tests/dune
@@ -1,60 +1,39 @@
-(alias
- (name github_action_tests)
+(rule
+ (alias github_action_tests)
+ (action
+  (run ./ssl_version.exe))
  (deps
   (alias_rec runtest)))
-
-(library
- (name util)
- (modules util)
- (libraries ssl threads str alcotest))
-
-(test
- (name ssl_test)
- (modules ssl_test)
- (libraries ssl alcotest)
- (deps digicert_certificate.pem))
-
-(test
- (name ssl_comm)
- (modules ssl_comm)
- (libraries ssl alcotest))
 
 (executable
  (name ssl_version)
  (modules ssl_version)
  (libraries ssl alcotest))
 
-(rule
- (alias github_action_tests)
- (action
-  (run ./ssl_version.exe)))
+(library
+ (name util)
+ (modules util)
+ (libraries ssl threads str alcotest))
 
-(test
- (name ssl_context)
- (modules ssl_context)
+(tests
+ (names ssl_test ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
+ (modules
+  ssl_test
+  ssl_comm
+  ssl_context
+  ssl_ciphers
+  ssl_certs
+  ssl_sock
+  ssl_io)
  (libraries ssl alcotest util)
- (deps client.pem client.key server.key ca.pem ca.key))
-
-(test
- (name ssl_ciphers)
- (modules ssl_ciphers)
- (libraries ssl alcotest util)
- (deps client.pem client.key dh4096.pem server.key server.pem))
-
-(test
- (name ssl_certs)
- (modules ssl_certs)
- (libraries ssl alcotest util)
- (deps client.pem ca.pem ca.key server.key server.pem))
-
-(test
- (name ssl_sock)
- (modules ssl_sock)
- (libraries ssl alcotest util)
- (deps ca.pem ca.key server.key server.pem))
-
-(test
- (name ssl_io)
- (modules ssl_io)
- (libraries ssl alcotest util)
- (deps ca.pem ca.key server.key server.pem))
+ (deps
+  digicert_certificate.pem
+  client.pem
+  client.key
+  dh4096.pem
+  server.key
+  server.pem
+  ca.pem
+  ca.key)
+ (enabled_if
+  (<> %{os_type} "Win32")))

--- a/tests/dune
+++ b/tests/dune
@@ -16,15 +16,22 @@
  (libraries ssl threads str alcotest))
 
 (tests
- (names ssl_test ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
- (modules
-  ssl_test
-  ssl_comm
-  ssl_context
-  ssl_ciphers
-  ssl_certs
-  ssl_sock
-  ssl_io)
+ (names ssl_test)
+ (modules ssl_test)
+ (libraries ssl alcotest util)
+ (deps
+  digicert_certificate.pem
+  client.pem
+  client.key
+  dh4096.pem
+  server.key
+  server.pem
+  ca.pem
+  ca.key))
+
+(tests
+ (names ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
+ (modules ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
  (libraries ssl alcotest util)
  (deps
   digicert_certificate.pem

--- a/tests/dune
+++ b/tests/dune
@@ -16,8 +16,8 @@
  (libraries ssl threads str alcotest))
 
 (tests
- (names ssl_test)
- (modules ssl_test)
+ (names ssl_test ssl_certs)
+ (modules ssl_test ssl_certs)
  (libraries ssl alcotest util)
  (deps
   digicert_certificate.pem
@@ -32,8 +32,8 @@
   (<> %{os_type} "Win32")))
 
 (tests
- (names ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
- (modules ssl_comm ssl_context ssl_ciphers ssl_certs ssl_sock ssl_io)
+ (names ssl_comm ssl_context ssl_ciphers ssl_sock ssl_io)
+ (modules ssl_comm ssl_context ssl_ciphers ssl_sock ssl_io)
  (libraries ssl alcotest util)
  (deps
   digicert_certificate.pem


### PR DESCRIPTION
- given the successful run of #156, will try a different approach of enabling tests on windows one by one to see the failures
- disabling tests in the dune file also helps set the repo up for a release that is compatible with the opam-repository CI